### PR TITLE
Make more magit functions to go full screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,11 @@ unstage a file, and the capital <kbd>S</kbd> to stage all of them. Use the
 ask for the commit message (<kbd>C-c C-c</kbd> to close the window and
 commit). Finally the <kbd>q</kbd> key quits magit.
 
+By default running [Magit](http://magit.vc) via global keybindings will start it
+in a full screen mode (whole frame). This is controlled by
+`exordium-use-magit-fullscreen` preference. You can [customize](#customization) it
+to `nil` to get original [Magit](http://magit.vc) behavior.
+
 The screenshot above also shows
 [git gutter](https://github.com/syohex/emacs-git-gutter) in the top buffer. Git
 gutter displays a git diff of the file in the left-side fringe (you can

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -71,9 +71,10 @@
 
   :config
 ;;; Make `magit-status',`exordium-magit-log' (a wrapper around `magit-log' and
-;;; `magit-dired-log'), and `magit-status-internal' (called from
-;;; `projectile-vc') to run alone in the frame, and then restore the old window
-;;; configuration when you quit out of magit.
+;;; `magit-dired-log'), `magit-status-setup-buffer' (called from `magit-clone'),
+;;; and `magit-status-internal' (called from `projectile-vc') to run alone in
+;;; the frame, and then restore the old window configuration when you quit out
+;;; of magit.
   (when exordium-use-magit-fullscreen
     (defun exordium-define-advice-magit-fullscreen (symbol)
       (cl-flet ((advice (orig-fun &rest args)
@@ -83,6 +84,7 @@
         (advice-add symbol :around #'advice)))
     (exordium-define-advice-magit-fullscreen 'magit-status)
     (exordium-define-advice-magit-fullscreen 'exordium-magit-log)
+    (exordium-define-advice-magit-fullscreen 'magit-status-setup-buffer)
     (when (fboundp 'magit-status-internal) ;; check just like in `projectile-vc'
       (exordium-define-advice-magit-fullscreen 'magit-status-internal)))
   )

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -70,21 +70,23 @@
         )
 
   :config
-;;; Make `magit-status',`exordium-magit-log' (a wrapper around `magit-log'),
-;;; and `magit-status-internal' (called from `projectile-vc') to run alone in
-;;; the frame, and then restore the old window configuration when you quit out
-;;; of magit.
-  (defun exordium-define-advice-magit-fullscreen (symbol)
-    (cl-flet ((advice (orig-fun &rest args)
-                      (window-configuration-to-register :magit-fullscreen)
-                      (apply orig-fun args)
-                      (delete-other-windows)))
-      (advice-add symbol :around #'advice)))
-  (exordium-define-advice-magit-fullscreen 'magit-status)
-  (exordium-define-advice-magit-fullscreen 'exordium-magit-log)
-  (when (fboundp 'magit-status-internal) ;; check just like in `projectile-vc'
-    (exordium-define-advice-magit-fullscreen 'magit-status-internal))
+;;; Make `magit-status',`exordium-magit-log' (a wrapper around `magit-log' and
+;;; `magit-dired-log'), and `magit-status-internal' (called from
+;;; `projectile-vc') to run alone in the frame, and then restore the old window
+;;; configuration when you quit out of magit.
+  (when exordium-use-magit-fullscreen
+    (defun exordium-define-advice-magit-fullscreen (symbol)
+      (cl-flet ((advice (orig-fun &rest args)
+                        (window-configuration-to-register :magit-fullscreen)
+                        (apply orig-fun args)
+                        (delete-other-windows)))
+        (advice-add symbol :around #'advice)))
+    (exordium-define-advice-magit-fullscreen 'magit-status)
+    (exordium-define-advice-magit-fullscreen 'exordium-magit-log)
+    (when (fboundp 'magit-status-internal) ;; check just like in `projectile-vc'
+      (exordium-define-advice-magit-fullscreen 'magit-status-internal)))
   )
+
 
 
 ;;; Keys

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -111,8 +111,14 @@ This makes it easier to paste text from the Windows clipboard."
 
 ;;; Backup files (e.g. file~)
 (defcustom exordium-backup-files nil
-  "Enables or disables backup files. Disabled by default, I can't
-  stand these annoying files~"
+  "Enables or disables backup files.
+Disabled by default, I can't stand these annoying files~"
+  :group 'exordium
+  :type  'boolean)
+
+(defcustom exordium-use-magit-fullscreen t
+  "If t, magit status and log will fill the whole frame.
+The original window configuration will be restored when you quit out of magit."
   :group 'exordium
   :type  'boolean)
 


### PR DESCRIPTION
In the beginning I didn't like it, but now I found that lack of full-screen
after `M-g` in `helm-projectile-switch-project` causes a dissonance. Decided to
do more robust checks.

Apologies for the ugly advice names, but didn't want to repeat the same code
more times, nor I know how to do macros inside a macros that want symbols
etc... my `elisp` still needs more refinements...