### PR TITLE
Switch to org-superstar

### DIFF
--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -47,9 +47,9 @@
 
 
 ;;; Show org-mode bullets as UTF-8 characters.
-(use-package org-bullets
+(use-package org-superstar
   :hook
-  (org-mode . (lambda () (org-bullets-mode 1))))
+  (org-mode . (lambda () (org-superstar-mode 1))))
 
 ;;; visual line mode in org-mode, paragraphs without embedded newline
 


### PR DESCRIPTION
org-bullets is deprecated, and latest version in MELPA is actually
empty. Probably a bug, but superstar is the maintained successor, and a drop-in
replacement.