### PR TITLE
Change to cl-lib to handle deprecation of cl in 27

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -78,7 +78,7 @@
 ;;; region or comment block.
 ;;; TODO: the regex should be fixed for words like "e.g." or "i.e.".
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 (use-package cc-defs :ensure nil)
 (use-package cc-vars :ensure nil)
 (use-package cc-mode)

--- a/modules/init-bde-style.t.el
+++ b/modules/init-bde-style.t.el
@@ -3,7 +3,7 @@
 ;;;     M-x eval-buffer
 ;;;     M-x ert
 
-(with-no-warnings (require 'cl))
+(require 'cl-lib)
 (require 'init-bde-style)
 
 ;; Test apparatus

--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -10,7 +10,7 @@
 ;;; - Open .h files in C++ mode by default
 ;;; - Highlight dead code between #if 0 and #endif (after saving)
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 (require 'init-lib)
 
 (use-package cc-mode
@@ -95,7 +95,7 @@
       (cond (matching-ext
              (unless
                  (catch 'found
-                   (flet ((when-exists-find-and-throw
+                   (cl-flet ((when-exists-find-and-throw
                            (file)
                            (when (file-exists-p file)
                              (find-file file)
@@ -150,7 +150,7 @@
 ;;; C++11 keywords
 
 (require 'init-prefs)
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 
 (defconst exordium-extra-c++-keywords
   (remove-if #'null

--- a/modules/init-flb-mode.el
+++ b/modules/init-flb-mode.el
@@ -36,7 +36,7 @@
 ;;
 ;; TODO: implement support for bury-buffer in FLB mode
 
-(use-package cl)
+(use-package cl-lib :ensure nil)
 
 (define-minor-mode flb-mode
   "Frame-local buffer mode. This macro defines both a function

--- a/modules/init-iwyu.el
+++ b/modules/init-iwyu.el
@@ -8,7 +8,7 @@
 ;;; C-c w d    `iwyu-show-diagnostics-buffer'
 ;;; g          `iwyu-start-process-for' (in `IWYU-mode' buffer)
 
-(use-package cl)
+(use-package cl-lib :ensure nil)
 (use-package compile)
 
 ;;;###autoload

--- a/modules/init-lib.el
+++ b/modules/init-lib.el
@@ -3,7 +3,7 @@
 ;;; This file defines utility functions reused in other modules. It should be
 ;;; loaded before any other module.
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 
 
 ;;; Files
@@ -77,7 +77,7 @@ attention to case differences."
     "Remove leading and trailing whitespace from STRING."
     (string-trim-left (string-trim-right string))))
 
-(eval-when-compile (assert (not (fboundp 'string-truncate))))
+(eval-when-compile (cl-assert (not (fboundp 'string-truncate))))
 
 (defun string-truncate (string n)
   "Return STRING minus the last N characters."

--- a/modules/init-look-and-feel.el
+++ b/modules/init-look-and-feel.el
@@ -26,14 +26,14 @@
 ;;; F10               Speedbar
 ;;; ----------------- ---------------------------------------------------------
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 (require 'init-prefs)
 
 
 ;;; Font
 
 (defvar exordium-available-preferred-fonts
-  (remove-if-not (lambda (font-and-size)
+  (cl-remove-if-not (lambda (font-and-size)
                    (member (car font-and-size) (font-family-list)))
                  exordium-preferred-fonts))
 

--- a/modules/init-rtags-cdb.el
+++ b/modules/init-rtags-cdb.el
@@ -54,7 +54,7 @@
 ;;; - Create `compilation_database.json' (it overwrites without asking)
 ;;; - Ask if you want to reload it (if rdm is running).
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 (require 'init-lib)
 
 ;; Override these variables in your .emacs as needed:

--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -122,7 +122,7 @@
 ;;; - "C-c r D" or M-x `rtags-diagnostics' to start,
 ;;; - "C-c r q" or M-x `rtags-stop-diagnostics' to terminate the subprocess.
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 (require 'init-lib)
 (require 'init-prefs)
 (use-package rtags)

--- a/modules/init-smooth-scroll.el
+++ b/modules/init-smooth-scroll.el
@@ -26,7 +26,7 @@
 ;;; Credit: the algorithm is from the Sublimity plugin, but fine-tuned.
 ;;; See https://github.com/zk-phi/sublimity
 
-(with-no-warnings (use-package cl))
+(use-package cl-lib :ensure nil)
 
 
 ;;; Customizable variables


### PR DESCRIPTION
Emacs 27 is deprecating cl. Switch to using cl-lib instead.