### PR TITLE
Add project to projectile after magit-clone

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -87,6 +87,11 @@
     (exordium-define-advice-magit-fullscreen 'magit-status-setup-buffer)
     (when (fboundp 'magit-status-internal) ;; check just like in `projectile-vc'
       (exordium-define-advice-magit-fullscreen 'magit-status-internal)))
+
+  (define-advice magit-clone-regular (:after
+                                      (_repo directory _args)
+                                      exordium-projectile-add-known-project)
+    (projectile-add-known-project directory))
   )
 
 


### PR DESCRIPTION
After doing `magit-clone` (<kbd>C-c g c</kbd>) `magit-status` buffer is
automatically open. This however doesn't add it to `projectile`'s known
projects. It stays this way until a file from a fresh clone is open. When in
this state it's not possible to quickly go to the project with
<kbd>C-c H</kbd> (i.e., `helm-projectile`).

This commit adds advice to automatically add a project to a list of
`projectile`'s know projects after `magit-clone`.