### PR TITLE
Tune Tomorrow theme for Org mode

### DIFF
--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -321,9 +321,16 @@ names to which it refers are bound."
      (grep-hit-face ((t (:foreground ,blue))))
      (grep-match-face ((t (:foreground nil :background nil :inherit match))))
 
+     ;; Man
+     (Man-overstrike ((t (:foreground ,orange))))
+     (Man-underline ((t (:foreground ,green))))
+
      ;; Org
      (org-level-1 ((t
-                    ,(append `(:foreground ,foreground)
+                    ,(append `(:foreground ,green
+                               :overline ,green
+                               :background ,selection
+                               :box (:style released-button))
                              (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
      (org-level-2 ((t (:foreground ,aqua))))
      (org-level-3 ((t (:foreground ,purple))))


### PR DESCRIPTION
Org's level one now looks like this:

<img width="457" alt="Screen Shot 2020-03-27 at 9 14 04 AM" src="https://user-images.githubusercontent.com/2925855/77759591-5585ba80-700b-11ea-800e-c61cae5584cf.png">
