### PR TITLE
Use native display-fill-column-indicator on Emacs 27 and above

### DIFF
--- a/modules/init-look-and-feel.el
+++ b/modules/init-look-and-feel.el
@@ -58,7 +58,8 @@
       (set-face-attribute 'default nil
                           :family font
                           :height size
-                          :weight 'normal))))
+                          :weight 'normal)
+      t))) ;; indicate that the font has been set
 
 (when exordium-preferred-fonts
   (exordium-set-font))

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -5,9 +5,12 @@
   :commands (org-mode)
   :mode (("\\.org\\'" . org-mode))
   :init
-  (add-hook 'org-src-mode-hook
-            (lambda ()
-              (turn-off-fci-mode)))
+  (use-package fill-column-indicator
+    :if (version< emacs-version "27")
+    :config
+    (add-hook 'org-src-mode-hook
+              (lambda ()
+                (turn-off-fci-mode))))
 
     (add-hook 'org-mode-hook 'turn-on-visual-line-mode)
 
@@ -43,7 +46,6 @@
        (C          . t)
        (dot        . t)))))
 
-(use-package fill-column-indicator)
 
 
 ;;; Show org-mode bullets as UTF-8 characters.

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -193,16 +193,15 @@ font."
   :group 'exordium
   :type  'symbol)
 
-(defcustom exordium-fci-dashes-alist '((:one .   ?\u2575)  ;; ╵
-                                       (:two .   ?\u254e)  ;; ╎
-                                       (:three . ?\u2506)  ;; ┆
-                                       (:four .  ?\u250a)) ;; ┊
-  "The mapping form a symbol to a character to be used when displaying dashes.
-If the value of `exordium-fci-use-dashes' cannot be mapped or the mapped value
-cannot be displayed by the current font default will be used.
-
-Probably the char ?\u2758 `❘' could be better, but it's not as common in fonts,
-i.e., (Fira Code doesn't have it)."
+(defcustom exordium-fci-dashes-alist '((:one .   (?\u2758 ?\u2575)) ;; ❘ or ╵
+                                       (:two .   (?\u254e))         ;; ╎
+                                       (:three . (?\u2506))         ;; ┆
+                                       (:four .  (?\u250a)))       ;; ┊
+  "The mapping form a symbol to a sequence of characters to be used for dashes.
+For each symbol the first displayable character from the sequence will be used
+if displayable in current configuration.  If the value of
+`exordium-fci-use-dashes' cannot be mapped or the mapped value cannot be
+displayed by the current font default will be used."
   :group 'exordium
   :type  'alist)
 

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -184,11 +184,27 @@ nil means it is disabled."
   :group 'exordium
   :type  'symbol)
 
-(defcustom exordium-fci-use-dashes t
-  "If t, use dashes for fill-column-indicator.
-If nil, use a plain line."
+(defcustom exordium-fci-use-dashes :one
+  "If non-nil use dashes for fill-column-indicator.
+If nil, use a plain line.  The value can be one of `:one', `:two', `:three',
+`:four', or any other key from `exordium-fci-dashes-alist' to use associated
+value.  Note that the character will only be used if displayable by a current
+font."
   :group 'exordium
-  :type  'boolean)
+  :type  'symbol)
+
+(defcustom exordium-fci-dashes-alist '((:one .   ?\u2575)  ;; ╵
+                                       (:two .   ?\u254e)  ;; ╎
+                                       (:three . ?\u2506)  ;; ┆
+                                       (:four .  ?\u250a)) ;; ┊
+  "The mapping form a symbol to a character to be used when displaying dashes.
+If the value of `exordium-fci-use-dashes' cannot be mapped or the mapped value
+cannot be displayed by the current font default will be used.
+
+Probably the char ?\u2758 `❘' could be better, but it's not as common in fonts,
+i.e., (Fira Code doesn't have it)."
+  :group 'exordium
+  :type  'alist)
 
 (defcustom exordium-fci-fix-autocomplete-bug t
   "Whether fill-column-indicator is temporarily disabled when an

--- a/modules/init-prog-mode.el
+++ b/modules/init-prog-mode.el
@@ -63,11 +63,5 @@
 
 
 
-
-;;; Fill column indicator
-(when (eq exordium-fci-mode :prog)
-  (add-hook 'prog-mode-hook 'fci-mode))
-
-
 (provide 'init-prog-mode)
 ;; End of file

--- a/modules/init-themes.el
+++ b/modules/init-themes.el
@@ -22,7 +22,8 @@
 
 (require 'init-prefs)
 (eval-when-compile
-  (use-package fill-column-indicator)
+  (use-package fill-column-indicator
+    :if (version< emacs-version "27"))
   (require 'hilinum-mode)
   (use-package powerline))
 
@@ -66,7 +67,8 @@
 
 ;;; FCI (80-column marker) color
 
-(when exordium-fci-mode
+(when (and exordium-fci-mode
+           (version< emacs-version "27"))
   (use-package fill-column-indicator)
   (let ((color (and (facep 'vertical-border)
                     (face-foreground 'vertical-border))))

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -261,64 +261,118 @@ With argument, do this that many times."
 
 
 ;;; FCI: 80-column ruler bound to Ctrl-|
+
+(if (version< emacs-version "27")
 ;;; Note: if it causes Emacs to crash on images, set the variable
 ;;; fci-always-use-textual-rule to t (it will use a character instead).
+    (progn
+      (eval-when-compile
+        (use-package fill-column-indicator))
 
-(eval-when-compile
-  (use-package fill-column-indicator))
+      (when exordium-fci-mode
+        (use-package fill-column-indicator)
 
-(when exordium-fci-mode
-  (use-package fill-column-indicator)
+        (when exordium-fci-use-dashes
+          (setq fci-rule-use-dashes t)
+          (setq fci-dash-pattern 0.5))
+        (setq fci-rule-width 1)
 
-  (when exordium-fci-use-dashes
-    (setq fci-rule-use-dashes t)
-    (setq fci-dash-pattern 0.5))
-  (setq fci-rule-width 1)
+        (define-key global-map [(control |)]
+          #'(lambda ()
+              (interactive)
+              (fci-mode (if fci-mode 0 1))))
 
-  (define-key global-map [(control |)]
-    #'(lambda ()
-        (interactive)
-        (fci-mode (if fci-mode 0 1))))
+        (cond
+         ((eq exordium-fci-mode :always)
+          (define-globalized-minor-mode global-fci-mode fci-mode
+            (lambda () (fci-mode 1)))
+          (global-fci-mode 1))
+         ((eq exordium-fci-mode :prog)
+          (add-hook 'prog-mode-hook 'fci-mode)))
 
-  (when (eq exordium-fci-mode :always)
-    (define-globalized-minor-mode global-fci-mode fci-mode
-      (lambda () (fci-mode 1)))
-    (global-fci-mode 1)))
-
-;;; Fix a display bug in auto-complete caused by FCI. See
-;;; https://github.com/alpaker/Fill-Column-Indicator/issues/21
-
-(when (and exordium-fci-mode
-           (eq exordium-complete-mode :auto-complete)
-           exordium-fci-fix-autocomplete-bug)
-  (use-package fill-column-indicator)
-  (use-package popup)
+          ;;; Fix a display bug in auto-complete caused by FCI. See
+          ;;; https://github.com/alpaker/Fill-Column-Indicator/issues/21
+        (when (and (eq exordium-complete-mode :auto-complete)
+                   exordium-fci-fix-autocomplete-bug)
+          (use-package fill-column-indicator)
+          (use-package popup)
 
   ;;; fci-mode turns line truncation on by default (see
   ;;; `fci-handle-truncate-lines'); this is pretty annoying when you have long
   ;;; lines and fci-mode goes off (to display popup) and your line truncation
-  ;;; goes off. Hence, for popups we turn off this handler and let `fc-mode'
+  ;;; goes off. Hence, for popups we turn off this handler and let `fci-mode'
   ;;; relay on whatever buffer value of `truncate-lines' is.
 
-  (defvar exordium-fci-mode-suppressed nil)
+          (defvar exordium-fci-mode-suppressed nil)
 
-  (defadvice popup-create (before suppress-fci-mode activate)
-    "Suspend fci-mode while popups are visible"
-    (let ((fci-enabled (and (boundp 'fci-mode) fci-mode)))
-      (when fci-enabled
-        (set (make-local-variable 'exordium-fci-mode-suppressed) fci-enabled)
-        (set (make-local-variable 'exordium-fci-handle-truncate-lines)
-             fci-handle-truncate-lines)
-        (setq fci-handle-truncate-lines nil)
-        (turn-off-fci-mode))))
+          (defadvice popup-create (before suppress-fci-mode activate)
+            "Suspend fci-mode while popups are visible"
+            (let ((fci-enabled (and (boundp 'fci-mode) fci-mode)))
+              (when fci-enabled
+                (set (make-local-variable 'exordium-fci-mode-suppressed) fci-enabled)
+                (set (make-local-variable 'exordium-fci-handle-truncate-lines)
+                     fci-handle-truncate-lines)
+                (setq fci-handle-truncate-lines nil)
+                (turn-off-fci-mode))))
 
-  (defadvice popup-delete (after restore-fci-mode activate)
-    "Restore fci-mode when all popups have closed"
-    (when (and exordium-fci-mode-suppressed
-               (null popup-instances))
-      (setq exordium-fci-mode-suppressed nil)
-      (setq fci-handle-truncate-lines 'exordium-fci-handle-truncate-lines)
-      (turn-on-fci-mode))))
+          (defadvice popup-delete (after restore-fci-mode activate)
+            "Restore fci-mode when all popups have closed"
+            (when (and exordium-fci-mode-suppressed
+                       (null popup-instances))
+              (setq exordium-fci-mode-suppressed nil)
+              (setq fci-handle-truncate-lines 'exordium-fci-handle-truncate-lines)
+              (turn-on-fci-mode))))))
+
+  ;; else (not (version< emacs-version "27")) use native package
+  (use-package display-fill-column-indicator
+    :if exordium-fci-mode
+    :ensure nil
+    :bind ("C-|" . display-fill-column-indicator-mode)
+    :init
+    (defun exordium--select-display-fill-column-indicator-character ()
+      (cl-flet
+          ((char-or-nil
+            (char)
+            ;; Return the `char' if displayable. Return nil otherwise.
+            ;; This is the same check as in `display-fill-column-indicator-mode'
+            ;; but with `string=' the check for faces equality (for some reason
+            ;; `eq' doesn't work when initialising).
+            (when (and char
+                       (char-displayable-p char)
+                       (or (not (display-graphic-p))
+                           (string=
+                            (aref (query-font (car (internal-char-font nil char)))
+                                  0)
+                            (face-font 'default))))
+              char)))
+        (prog1
+            (setq-default display-fill-column-indicator-character
+                          (char-or-nil
+                           (alist-get (if (eq exordium-fci-use-dashes t)
+                                          :one
+                                        exordium-fci-use-dashes)
+                                      exordium-fci-dashes-alist)))
+          (when (and exordium-fci-use-dashes
+                     (not display-fill-column-indicator-character))
+            (message
+             (concat "Selected exordium-fci-dashes: %s with mapped char: %s "
+                     "cannot be used as a display-fill-column-indicator-character "
+                     " with the face-font: %s.")
+             exordium-fci-use-dashes
+             (alist-get exordium-fci-use-dashes exordium-fci-dashes-alist)
+             (face-font 'default))))))
+    (exordium--select-display-fill-column-indicator-character)
+
+    :config
+    (cond
+     ((eq exordium-fci-mode :always)
+      (global-display-fill-column-indicator-mode))
+     ((eq exordium-fci-mode :prog)
+      (add-hook 'prog-mode-hook
+                #'display-fill-column-indicator-mode)))
+    ;; `init-util' is loaded only after `init-look-and-feel', so let's do advice
+    (define-advice exordium-set-font (:after-while (&rest _args))
+                (exordium--select-display-fill-column-indicator-character))))
 
 
 ;;; Avy - go to any word on the screen in just 2 or 3 keystrokes.

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -347,7 +347,8 @@ With argument, do this that many times."
               char)))
         (prog1
             (setq-default display-fill-column-indicator-character
-                          (char-or-nil
+                          (seq-find
+                           #'char-or-nil
                            (alist-get (if (eq exordium-fci-use-dashes t)
                                           :one
                                         exordium-fci-use-dashes)

--- a/themes/color-theme-atom-one.el
+++ b/themes/color-theme-atom-one.el
@@ -457,6 +457,16 @@ names to which it refers are bound."
    (apply 'custom-theme-set-faces 'atom-one (atom-one-face-specs)))
   (provide-theme 'atom-one))
 
+;;; Debugging functions
+
+(defun set-colors-atom-one ()
+  "Sets the colors to the monokai theme"
+  (interactive)
+  (with-atom-one-colors
+   'default
+   (apply 'custom-set-faces (atom-one-face-specs))))
+
+
 (provide 'color-theme-atom-one)
 
 ;; Local Variables:

--- a/themes/color-theme-atom-one.el
+++ b/themes/color-theme-atom-one.el
@@ -114,6 +114,7 @@ names to which it refers are bound."
 
      (query-replace ((t (:inherit (isearch)))))
      (minibuffer-prompt ((t (:foreground ,atom-one-dark-silver))))
+     (fill-column-indicator ((t (:foreground "dim gray" :background ,atom-one-dark-bg))))
 
      ;; Customize
      (custom-variable-tag ((t (:foreground ,atom-one-dark-blue))))

--- a/themes/color-theme-github-modern.el
+++ b/themes/color-theme-github-modern.el
@@ -111,6 +111,7 @@ names to which it refers are bound."
      (secondary-selection ((t (:background ,github-white))))
      (trailing-whitespace ((t (:background ,github-string))))
      (vertical-border ((t (:foreground ,github-border))))
+     (fill-column-indicator ((t (:foreground ,github-comment :background ,github-white))))
 ;;;;; font lock
      (font-lock-builtin-face ((t (:foreground ,github-keyword))))
      (font-lock-comment-face ((t (:foreground ,github-comment))))

--- a/themes/color-theme-material.el
+++ b/themes/color-theme-material.el
@@ -128,6 +128,8 @@ names to which it refers are bound."
      (widget-button ((t (:underline t))))
      (widget-field ((t (:background ,current-line :box (:line-width 1 :color ,foreground)))))
      (menu ((t (:foreground ,foreground :background ,background))))
+          (fill-column-indicator ((t (:foreground "dim gray" :background ,background))))
+
 
      ;; Mode line
      (mode-line ((t (:background ,black ; for powerline (previously far-background)

--- a/themes/color-theme-monokai.el
+++ b/themes/color-theme-monokai.el
@@ -272,6 +272,7 @@ names to which it refers are bound."
      (secondary-selection ((t (:background ,monokai-hl :inherit t))))
      (trailing-whitespace ((t (:background ,red))))
      (vertical-border ((t (:foreground ,monokai-hl))))
+     (fill-column-indicator ((t (:foreground "dim gray" :background ,monokai-bg))))
 
      ;; auto-complete
      (ac-candidate-face ((t (:background ,monokai-hl :foreground ,cyan))))

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -105,6 +105,7 @@ names to which it refers are bound."
      (link ((t (:foreground ,violet :underline t))))
      (link-visited ((t (:foreground ,magenta :underline t))))
      (vertical-border ((t (:foreground ,base0))))
+     (fill-column-indicator ((t (:foreground ,base01 :background ,back))))
 
      ;; Mode line
      (minibuffer-prompt ((t (:weight bold :foreground ,cyan))))

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -179,6 +179,7 @@ names to which it refers are bound."
       ((t (:background ,current-line :box (:line-width 1 :color ,foreground)))))
      (header-line ((t (:foreground ,purple :background nil))))
      (menu ((t (:foreground ,foreground :background ,selection))))
+     (fill-column-indicator ((t (:foreground "dim gray" :background ,background))))
 
      ;; Customize
      (custom-variable-tag ((t (:foreground ,blue))))

--- a/themes/color-theme-zenburn.el
+++ b/themes/color-theme-zenburn.el
@@ -146,6 +146,7 @@ names to which it refers are bound."
      (secondary-selection ((t (:background ,zenburn-bg+2))))
      (trailing-whitespace ((t (:background ,zenburn-red))))
      (vertical-border ((t (:foreground ,zenburn-fg))))
+     (fill-column-indicator ((t (:foreground ,zenburn-bg+05 :background ,zenburn-bg))))
 
      ;; Hi-Lock
      (hi-blue    ((t (:background ,zenburn-cyan    :foreground ,zenburn-bg-1))))


### PR DESCRIPTION
This replaces the `fill-column-indicator` a.k.a `fci-mode` with the native `display-fill-column-indicator-mode`. The old mode is still used when `emacs-version` is below 27 (i.e., the new native mode is not available).

The new mode look and fill replicates the old one with the following modifications:
- It's now possible to define how the dashes should be displayed via `exordium-fci-use-dashes` value and fine tune it with `exordium-fci-dashes-alist`. Old settings are still supported.
- The temporary buffer for org source code blocks is not inhibiting the new indicator. While that behaviour is there for the last 5 years (introduced by @steve-downey in: fe8be638679f5edfc2cc3e834b02e071e4d78219), it lacks motivation and  I think that lack of indicator there is quite surprising. Especially when the `exordium-fci-use-dashes` is set to `:prog`. I'm happy to add it if there's a strong demand, but would probably guard it with yet one more configuration variable.

I've also tried to convert the old mode to be configured under `use-pacakage`, but hasn't achieved much success in a reasonable time. If the new mode is accepted then we may want to think how much backward compatibility we need and how much we want to invest in that. Read: likely a separate PR for that work 🤔.

For the colours I copied what I found in existing configuration (with the exception of `solarized` theme that I've handpicked the value).

I validated the new configuration and the old configuration (by setting the minimum version to `"28"`) by restarting emacs with the following settings in my `prefs.el` followed by visiting buffers for `prog-mode` and non `prog-mode` and flipping the indicator a few times in each mode (<kbd>C-|</kbd>)
- `(setq exordium-fci-mode :always)`
  - `(setq exordium-fci-use-dashes nil)`
  - `(setq exordium-fci-use-dashes t)`
- `(setq exordium-fci-mode :ondemand)`
  - `(setq exordium-fci-use-dashes nil)`
  - `(setq exordium-fci-use-dashes :two)`
- `(setq exordium-fci-mode :prog)`
  - `(setq exordium-fci-use-dashes nil)`
  - `(setq exordium-fci-use-dashes :three)`

Screen shots below use [a modified Solarized Light theme](https://github.com/pkryger/exordium/tree/solarized-light). See line 152 for a character choice.

- with [a Fira Code](https://github.com/tonsky/FiraCode)
<img width="1680" alt="Screen Shot 2020-03-30 at 9 19 55 AM" src="https://user-images.githubusercontent.com/815559/77891238-93cbe580-7268-11ea-94b7-8daed293e2ca.png">

- with [DeajaVu Nerd Font](https://github.com/ryanoasis/nerd-fonts)
<img width="1680" alt="Screen Shot 2020-03-30 at 9 20 36 AM" src="https://user-images.githubusercontent.com/815559/77891265-9af2f380-7268-11ea-8a43-6f12d8c881b4.png">
