### PR TITLE
Use :slant normal for display-fill-column-indicator

### DIFF
--- a/themes/color-theme-atom-one.el
+++ b/themes/color-theme-atom-one.el
@@ -114,7 +114,7 @@ names to which it refers are bound."
 
      (query-replace ((t (:inherit (isearch)))))
      (minibuffer-prompt ((t (:foreground ,atom-one-dark-silver))))
-     (fill-column-indicator ((t (:foreground "dim gray" :background ,atom-one-dark-bg))))
+     (fill-column-indicator ((t (:foreground "dim gray" :background ,atom-one-dark-bg :slant normal))))
 
      ;; Customize
      (custom-variable-tag ((t (:foreground ,atom-one-dark-blue))))

--- a/themes/color-theme-github-modern.el
+++ b/themes/color-theme-github-modern.el
@@ -111,7 +111,7 @@ names to which it refers are bound."
      (secondary-selection ((t (:background ,github-white))))
      (trailing-whitespace ((t (:background ,github-string))))
      (vertical-border ((t (:foreground ,github-border))))
-     (fill-column-indicator ((t (:foreground ,github-comment :background ,github-white))))
+     (fill-column-indicator ((t (:foreground ,github-comment :background ,github-white :slant normal))))
 ;;;;; font lock
      (font-lock-builtin-face ((t (:foreground ,github-keyword))))
      (font-lock-comment-face ((t (:foreground ,github-comment))))

--- a/themes/color-theme-material.el
+++ b/themes/color-theme-material.el
@@ -128,7 +128,7 @@ names to which it refers are bound."
      (widget-button ((t (:underline t))))
      (widget-field ((t (:background ,current-line :box (:line-width 1 :color ,foreground)))))
      (menu ((t (:foreground ,foreground :background ,background))))
-          (fill-column-indicator ((t (:foreground "dim gray" :background ,background))))
+          (fill-column-indicator ((t (:foreground "dim gray" :background ,background :slant normal))))
 
 
      ;; Mode line

--- a/themes/color-theme-monokai.el
+++ b/themes/color-theme-monokai.el
@@ -272,7 +272,7 @@ names to which it refers are bound."
      (secondary-selection ((t (:background ,monokai-hl :inherit t))))
      (trailing-whitespace ((t (:background ,red))))
      (vertical-border ((t (:foreground ,monokai-hl))))
-     (fill-column-indicator ((t (:foreground "dim gray" :background ,monokai-bg))))
+     (fill-column-indicator ((t (:foreground "dim gray" :background ,monokai-bg :slant normal))))
 
      ;; auto-complete
      (ac-candidate-face ((t (:background ,monokai-hl :foreground ,cyan))))

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -105,7 +105,7 @@ names to which it refers are bound."
      (link ((t (:foreground ,violet :underline t))))
      (link-visited ((t (:foreground ,magenta :underline t))))
      (vertical-border ((t (:foreground ,base0))))
-     (fill-column-indicator ((t (:foreground ,base01 :background ,back))))
+     (fill-column-indicator ((t (:foreground ,base01 :background ,back :slant normal))))
 
      ;; Mode line
      (minibuffer-prompt ((t (:weight bold :foreground ,cyan))))

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -179,7 +179,7 @@ names to which it refers are bound."
       ((t (:background ,current-line :box (:line-width 1 :color ,foreground)))))
      (header-line ((t (:foreground ,purple :background nil))))
      (menu ((t (:foreground ,foreground :background ,selection))))
-     (fill-column-indicator ((t (:foreground "dim gray" :background ,background))))
+     (fill-column-indicator ((t (:foreground "dim gray" :background ,background :slant normal))))
 
      ;; Customize
      (custom-variable-tag ((t (:foreground ,blue))))

--- a/themes/color-theme-zenburn.el
+++ b/themes/color-theme-zenburn.el
@@ -146,7 +146,7 @@ names to which it refers are bound."
      (secondary-selection ((t (:background ,zenburn-bg+2))))
      (trailing-whitespace ((t (:background ,zenburn-red))))
      (vertical-border ((t (:foreground ,zenburn-fg))))
-     (fill-column-indicator ((t (:foreground ,zenburn-bg+05 :background ,zenburn-bg))))
+     (fill-column-indicator ((t (:foreground ,zenburn-bg+05 :background ,zenburn-bg :slant normal))))
 
      ;; Hi-Lock
      (hi-blue    ((t (:background ,zenburn-cyan    :foreground ,zenburn-bg-1))))


### PR DESCRIPTION
When the text with `:slant italic` is long enough to touch the column
indicator (but not cross it), the indicator inherits the slant from text. I'm
not finding this very pleasing. Fixing it to use `:slant normal`.

Without fix:
<img width="314" alt="Screen Shot 2020-03-31 at 10 55 37 AM" src="https://user-images.githubusercontent.com/815559/78015539-7159cb00-7341-11ea-920d-01835b634d91.png">
With fix:
<img width="283" alt="Screen Shot 2020-03-31 at 10 57 24 AM" src="https://user-images.githubusercontent.com/815559/78015567-79b20600-7341-11ea-8368-187fbc21d015.png">
