### PR TITLE
Diminish GitGutter from status line

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -116,13 +116,12 @@
   :config
   (exordium-global-git-gutter-mode t)
   (git-gutter:linum-setup)
-  :diminish
-  )
+  :diminish)
 
 (use-package git-gutter-fringe
   :if (and exordium-git-gutter (not exordium-git-gutter-non-fringe))
   :config (exordium-global-git-gutter-mode t)
-  :diminish
+  :diminish git-gutter-mode
   :bind (:map exordium-git-map
               ("<down>" . 'git-gutter:next-hunk)
               ("n" . 'git-gutter:next-hunk)


### PR DESCRIPTION
The `:diminish` by default use name of the package with added `-mode` to
automatically detect what to remove. However, in a case of `git-gutter-fringe`
we use `git-gutter-mode` and this was not working as intended, leaving
`GitGutter` in the status line. Fix this by explicitly providing minor mode symbol.