### PR TITLE
Add option to copy both buffer regions in ediff

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,14 @@ Git Timemachine key   | Description
 ----------------------|-----------------------------------------------------------
 <kbd>C-c g t</kbd>    | Enter the git time machine (`git-timemachine-toggle`)
 
+If you use `ediff` to solve merge conflicts you may find the following keys useful
+(in `*Ediff Control Panel*`):
+
+ediff key             | Description
+----------------------|-----------------------------------------------------------
+<kbd>A</kbd>          | Copy buffer A's region followed by buffer B's region to C
+<kbd>B</kbd>          | Copy buffer B's region followed by buffer A's region to C
+
 ## C++
 
 ### Utilities

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -174,26 +174,26 @@ Adapted from: http://stackoverflow.com/questions/9656311/conflict-resolution-wit
     (interactive
      (let ((first-string (completing-read "First: " '("A" "B") nil t "A"))
            (second-string (completing-read "Second: " '("A" "B") nil t "B")))
-       (list (intern first-string) (intern second-string))))
-    (let ((first (or first 'A))
-          (second (or second 'B)))
+       (list first-string second-string)))
+    (let ((first (or first "A"))
+          (second (or second "B")))
       (ediff-copy-diff ediff-current-difference nil 'C nil
                        (concat
                         (ediff-get-region-contents
-                         ediff-current-difference first ediff-control-buffer)
+                         ediff-current-difference (intern first) ediff-control-buffer)
                         (ediff-get-region-contents
-                         ediff-current-difference second ediff-control-buffer)))))
+                         ediff-current-difference (intern second) ediff-control-buffer)))))
 
   (defun exordium--add-copy-both-to-ediff-mode-map ()
     (when ediff-merge-job
       (define-key ediff-mode-map "A"
         #'(lambda ()
             (interactive)
-            (exordium-ediff-copy-both-to-C 'A 'B)))
+            (exordium-ediff-copy-both-to-C "A" "B")))
       (define-key ediff-mode-map "B"
         #'(lambda ()
             (interactive)
-            (exordium-ediff-copy-both-to-C 'B 'A)))))
+            (exordium-ediff-copy-both-to-C "B" "A")))))
 
   (defconst exordium--ediff-long-help-message-merge
     "

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -162,4 +162,69 @@
 (add-hook 'git-commit-mode-hook 'exordium-electric-mode-add-back-tick)
 
 
+(use-package ediff
+  :ensure nil
+  :defer t
+  :config
+  (defun exordium-ediff-copy-both-to-C (first second)
+    "Copy FIRST then SECOND into the C buffer in `ediff-mode'.
+This command should be called form `ediff''s control buffer.
+
+Adapted from: http://stackoverflow.com/questions/9656311/conflict-resolution-with-emacs-ediff-how-can-i-take-the-changes-of-both-version"
+    (interactive
+     (let ((first-string (completing-read "First: " '("A" "B") nil t "A"))
+           (second-string (completing-read "Second: " '("A" "B") nil t "B")))
+       (list (intern first-string) (intern second-string))))
+    (let ((first (or first 'A))
+          (second (or second 'B)))
+      (ediff-copy-diff ediff-current-difference nil 'C nil
+                       (concat
+                        (ediff-get-region-contents
+                         ediff-current-difference first ediff-control-buffer)
+                        (ediff-get-region-contents
+                         ediff-current-difference second ediff-control-buffer)))))
+
+  (defun exordium--add-copy-both-to-ediff-mode-map ()
+    (when ediff-merge-job
+      (define-key ediff-mode-map "A"
+        #'(lambda ()
+            (interactive)
+            (exordium-ediff-copy-both-to-C 'A 'B)))
+      (define-key ediff-mode-map "B"
+        #'(lambda ()
+            (interactive)
+            (exordium-ediff-copy-both-to-C 'B 'A)))))
+
+  (defconst exordium--ediff-long-help-message-merge
+    "
+p,DEL -previous diff |     | -vert/horiz split   |  x -copy buf X's region to C
+n,SPC -next diff     |     h -highlighting       |  X -copy both buf's regions
+    j -jump to diff  |     @ -auto-refinement    |     to C; X's region first
+   gx -goto X's point|    ## -ignore whitespace  |  r -restore buf C's old diff
+  C-l -recenter      | #f/#h -focus/hide regions |  * -refine current region
+  v/V -scroll up/dn  |     X -read-only in buf X |  ! -update diff regions
+  </> -scroll lt/rt  |     m -wide display       |  + -combine diff regions
+    ~ -swap variants |     s -shrink window C    | wx -save buf X
+                     |  $$ -show clashes only    | wd -save diff output
+                     |  $* -skip changed regions |  / -show/hide ancestor buff
+                     |                           |  & -merge w/new default
+"
+    "Help message for merge sessions.
+This is a copy of `ediff-long-help-message-merge' with addition of X key.")
+
+  (defun exordium--ediff-set-help-message()
+    "Redefine the `ediff-long-help-message' and `ediff-help-message'.
+This follows what `ediff-set-help-message' function is doing."
+    (when ediff-merge-job
+      (setq ediff-long-help-message
+            (concat ediff-long-help-message-head
+		            exordium--ediff-long-help-message-merge
+		            ediff-long-help-message-tail))
+      (when ediff-use-long-help-message
+        (setq ediff-help-message ediff-long-help-message))))
+
+  (add-hook 'ediff-display-help-hook 'exordium--ediff-set-help-message)
+  (add-hook 'ediff-keymap-setup-hook 'exordium--add-copy-both-to-ediff-mode-map))
+
+
 (provide 'init-git)


### PR DESCRIPTION
When solving merge conflicts with `ediff` I found myself more than once in a
need of having changes from both conflicting branches to be in final
merge. Sometimes they need refining, but usually parts of the conflicting
region were useful as is. IDK how to achieve that in a standard `ediff` without
selecting one change and then manually copying the other one.

This commit adds two keybindings to Ediff Control Panel: <kbd>A</kbd> and
<kbd>B</kbd>. They copy changes from both conflicting regions to the `C`
buffer. Two keys to allow for specifying order of yanks in a `C`.