### PR TITLE
Update solarized theme

### DIFF
--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -30,7 +30,7 @@
 ;;; C-|            Toggle FCI mode on and off ("Fill columm indicator",
 ;;;                e.g. the 80 column ruler)
 ;;;
-;;; C-j            Avy: jump to the beginning of any word on the screen. It
+;;; C-c j          Avy: jump to the beginning of any word on the screen. It
 ;;; C-'            asks for the first character of the word you want, and then
 ;;;                annotates each word that starts with this character with a
 ;;;                unique code of 1 or 2 letters. Type this code to jump

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -306,6 +306,9 @@ names to which it refers are bound."
      ;; Emacs Lisp
      (eval-sexp-fu-flash ((t (:background ,orange :foreground ,back))))
      (eval-sexp-fu-flash-error ((t (:background ,red :foreground ,back))))
+
+     ;; magit and forge
+     (forge-topic-closed ((t (:foreground ,base00))))
      )))
 
 (defmacro define-solarized-theme (mode)

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -256,8 +256,8 @@ names to which it refers are bound."
      (slime-warning-face ((t (:weight bold :foreground ,red))))
 
      ;;flyspell
-     (flyspell-incorrect ((t (:foreground ,red))))
-     (flyspell-duplicate ((t (:foreground ,yellow))))
+     (flyspell-incorrect ((t (:underline (:color ,red :style wave)))))
+     (flyspell-duplicate ((t (:underline (:color ,red :style wave)))))
 
      ;;ansi-term
      (term-color-black ((t ( :foreground ,base02))))

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -77,6 +77,11 @@ names to which it refers are bound."
      (region ((t (:foreground ,base2 :background ,base02))))
      (secondary-selection ((t (:background ,base02))))
 
+     ;; tab-bar
+     (tab-bar ((t (:foreground ,base0 :background ,base02))))
+     (tab-bar-tab ((t (:foreground ,base1 :background ,back))))
+     (tab-bar-tab-inactive ((t (:foreground ,base01 :background ,base02))))
+
      ;; font-lock
      (font-lock-builtin-face ((t (:foreground ,green :slant italic))))
      (font-lock-comment-face ((t (:foreground ,base01 :slant italic))))

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -6,6 +6,8 @@
 ;;; Greg Pfeil created a theme for Emacs. This file is a different
 ;;; implementation but uses the same choices for most faces.
 
+;;; see https://github.com/sellout/emacs-color-theme-solarized/blob/master/solarized-definitions.el
+;;; https://www.gnu.org/software/emacs/manual/html_node/emacs/Standard-Faces.html
 (require 'init-prefs)
 (require 'org)
 (require 'cl-lib)
@@ -67,7 +69,7 @@ names to which it refers are bound."
      (show-paren-mismatch ((t (:weight bold :foreground ,red :background ,base01))))
 
      ;; Region
-     (region ((t (:background ,base00))))
+     (region ((t (:foreground ,base2 :background ,base02))))
      (secondary-selection ((t (:background ,base02))))
 
      ;; font-lock
@@ -99,8 +101,10 @@ names to which it refers are bound."
      (fringe ((t (:foreground ,base01 :background ,base02))))
      (linum ((t (:foreground ,base01 :background ,base02))))
      (header-line ((t (:foreground ,base0 :background ,base02 :weight bold))))
-     (highlight ((t (:background ,base02))))
+     (highlight ((t (:foreground ,base2 :background ,base02))))
      (hl-line ((t (:background ,base02))))
+     (line-number ((t (:foreground ,base1 :background ,base02))))
+     (line-number-current-line ((t (:foreground ,base2 :background ,base02))))
      (menu ((t (:foreground ,base0 :background ,base02))))
      (link ((t (:foreground ,violet :underline t))))
      (link-visited ((t (:foreground ,magenta :underline t))))
@@ -180,6 +184,7 @@ names to which it refers are bound."
      (org-hide ((t (:foreground ,base03))))
      (org-todo ((t (:weight bold :foreground ,base03 :background ,red))))
      (org-done ((t (:weight bold :foreground ,green))))
+     (org-block ((t (:foreground ,base01 :background ,base02))))
      (org-todo-kwd-face ((t (:foreground ,red :background ,base03))))
      (org-done-kwd-face ((t (:foreground ,green :background ,base03))))
      (org-project-kwd-face ((t (:foreground ,violet :background ,base03))))

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -51,6 +51,11 @@
        (cl-rotatef base00 base0))
      ,@body))
 
+;; for testing do in a scratch:
+;; (let ((custom--inhibit-theme-enable nil))
+;;   (eval-buffer "color-theme-solarized.el")
+;;   (set-colors-solarized-light))
+
 (defmacro solarized-face-specs ()
   "Return a backquote which defines a list of face specs.
 It expects to be evaluated in a scope in which the various color


### PR DESCRIPTION
This update is focused on the `light` flavour. I found the original one to be a little bit too nettling to my eyes. And sometimes the text became plainly unreadable (i.e., `region`).

I've been using these fixes for a while now (if you take look at the commits history) and have not been finding much need to tweak it recently. Hence the PR.

As a last ditch, I've added tab-bar theme, that I've been using for a few days now.

I've also eye balled `dark` version and it seems to behave pretty consistently with the `light` version.