### PR TITLE
Add new face for markdown tables

### DIFF
--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -389,6 +389,7 @@ names to which it refers are bound."
      (markdown-markup-face ((t (:foreground ,blue))))
      (markdown-pre-face ((t (:foreground ,aqua))))
      (markdown-gfm-checkbox-face ((t (:foreground ,red))))
+     (markdown-table-face ((t (:foreground ,comment))))
 
      ;; js2-mode
      (js2-warning ((t (:underline (:color ,orange :style wave)))))


### PR DESCRIPTION
Just a small change in the Tomorrow's theme for tables. It looks like this:

<img width="729" alt="Screen Shot 2020-09-02 at 12 38 54 PM" src="https://user-images.githubusercontent.com/2925855/92011633-5be63400-ed19-11ea-91b7-3befc293a90a.png">
