### PR TITLE
Use cl-remove-if

### DIFF
--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -154,12 +154,12 @@
 (use-package cl-lib :ensure nil)
 
 (defconst exordium-extra-c++-keywords
-  (remove-if #'null
-             (list
-              ;; This can be completed with other things later (C++17?)
-              (when (eq exordium-enable-c++11-keywords :simple)
-                '("\\<\\(alignas\\|alignof\\|char16_t\\|char32_t\\|constexpr\\|decltype\\|noexcept\\|nullptr\\|static_assert\\|thread_local\\|override\\|final\\)\\>" . font-lock-keyword-face))))
-  "A-list of pairs (regex . face) for highlighting extra keywords in C++ mode")
+  (cl-remove-if #'null
+                (list
+                 ;; This can be completed with other things later (C++17?)
+                 (when (eq exordium-enable-c++11-keywords :simple)
+                   '("\\<\\(alignas\\|alignof\\|char16_t\\|char32_t\\|constexpr\\|decltype\\|noexcept\\|nullptr\\|static_assert\\|thread_local\\|override\\|final\\)\\>" . font-lock-keyword-face))))
+  "A-list of pairs (regex . face) for highlighting extra keywords in C++ mode.")
 
 (when exordium-extra-c++-keywords
   (add-hook 'c++-mode-hook

--- a/modules/init-iwyu.el
+++ b/modules/init-iwyu.el
@@ -115,8 +115,8 @@ arguments in `exordium-iwyu-extra-args'."
              "include-what-you-use"
              (append
               exordium-iwyu-extra-args
-              (remove-if '(lambda (x) (member x exordium-iwyu-filter-args))
-                         (iwyu-prepare-args (plist-get entry :command)))))
+              (cl-remove-if '(lambda (x) (member x exordium-iwyu-filter-args))
+                            (iwyu-prepare-args (plist-get entry :command)))))
             (display-buffer buffer-name)
             (other-window 1)
             (set-window-dedicated-p (get-buffer-window (current-buffer)) t)


### PR DESCRIPTION
Apparently `remove-if` is only an alias for `cl-remove-if`. Yet it's been giving me a warning in `init-cpp.el`. I scanned whole repo and use `cl-remove-if` consistently across it.