### PR TITLE
Refresh projectile set up and add ripgrep

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ expressions.
 * <kbd>C-S-s</kbd> or <kbd>M-x helm-swoop</kbd>: Swoop search for text in current buffer.
 * <kbd>C-S-d</kbd>: Ag search for text, but ask for directory to start first.
 * <kbd>C-S-f</kbd>: Ag search for text in current buffer (similar to Swoop).
-* <kbd>C-S-r</kbd>: Ag search starting from project root.
+* <kbd>C-S-r</kbd>: ripgrep search for text in current projectile project.
 * <kbd>M-x helm-multiple-swoop-all</kbd>: Swoop search within all buffers.
 
 ## Treemacs

--- a/modules/init-helm-projectile.el
+++ b/modules/init-helm-projectile.el
@@ -15,27 +15,31 @@
 ;;; C-S-s             Helm Swoop, a way of searching with Helm (try it!).
 ;;; C-c e             Project Explorer: show the directory tree.
 
+(require 'init-prefs)
 (use-package helm)
-(use-package projectile)
-(use-package helm-projectile)
+
+(use-package projectile
+  :bind
+  (:map projectile-command-map
+        ("." . helm-projectile-find-file-dwim))
+  :bind-keymap
+  ("C-c p" . projectile-command-map)
+  :config
+  (projectile-mode))
+
+(use-package helm-projectile
+  :config
+  (global-set-key [(control c)(h)] (function helm-projectile))
+  (global-set-key [(control c)(H)] (function helm-projectile-switch-project))
+  (global-set-key [(control c)(meta h)] (function helm-projectile-switch-project))
+  (when exordium-helm-everywhere
+    (helm-projectile-on)))
+
 (use-package helm-swoop
   :init
   ;; C-S-s = helm-swoop
   (define-key global-map [(control shift s)] (function helm-swoop)))
 (use-package treemacs-projectile)
-(require 'init-prefs)
-
-(projectile-global-mode)
-(global-set-key [(control c)(h)] (function helm-projectile))
-(global-set-key [(control c)(H)] (function helm-projectile-switch-project))
-(global-set-key [(control c)(meta h)] (function helm-projectile-switch-project))
-(when exordium-helm-everywhere
-  (substitute-key-definition
-   'projectile-switch-project 'helm-projectile-switch-project
-   projectile-mode-map)
-  (substitute-key-definition
-   'projectile-find-file 'helm-projectile
-   projectile-mode-map))
 
 ;; Prevent Projectile from indexing the build directory.
 (when exordium-rtags-cmake-build-dir

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -7,7 +7,7 @@
 ;;; M-y               Remap standard: Yank with helm.
 ;;; C-x b             Remap standard: Switch buffer with helm.
 ;;; C-x C-f           Remap standard: Find file with helm.
-;;; C-S-r             Search with Ag: from project root.
+;;; C-S-r             Search with ripgrep: in current projectile project.
 ;;; C-S-d             Search with Ag: ask for directory first.
 ;;; C-S-f             Search with Ag: this file (like Swoop).
 ;;; C-S-a             Search with Ag: in current projectile project.
@@ -15,13 +15,13 @@
 (use-package helm)
 (use-package helm-projectile)
 (use-package helm-ag)
+(use-package helm-rg)
 
 
-(global-set-key (kbd "C-S-r")   'helm-ag-project-root)
+(global-set-key (kbd "C-S-r")   'helm-projectile-rg)
 (global-set-key (kbd "C-S-d")   'helm-do-ag)
 (global-set-key (kbd "C-S-f")   'helm-do-ag-this-file)
 (global-set-key (kbd "C-S-a")   'helm-projectile-ag)
-(global-set-key (kbd "C-c p .") 'helm-projectile-find-file-dwim)
 
 (when exordium-helm-everywhere
   (helm-mode)


### PR DESCRIPTION
I noticed the `C-c p` has stopped working, so decided to give the setup a small refresh.

The `helm-projectile-on` is doing substitutions much more diligently, and I guess this is what is expected from `exordium-helm-everywhere`.

Since I've never used the `helm-ag-project-root` as the `C-S-a` was doing the same job I decided to give the binding to `helm-projectile-rg`. The `ripgrep` seems to be better in certain places than the Silver Searcher, i.e., it can do multi line searches.