### PR TITLE
Use `'other` for a `helm-split-window-default-side`

### DIFF
--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -12,7 +12,9 @@
 ;;; C-S-f             Search with Ag: this file (like Swoop).
 ;;; C-S-a             Search with Ag: in current projectile project.
 
-(use-package helm)
+(use-package helm
+  :custom
+  (helm-split-window-default-side 'other))
 (use-package helm-projectile)
 (use-package helm-ag)
 


### PR DESCRIPTION
Quite often I find myself wanting to type something from the _last_ window (where a `point` was at the time of invoking helm function), but the contents of the window are clobbered.

The value of  `other` works very close to the original value of `below`. The difference is when `point` is in a _last_ window. With the default value, when `helm-buffer` is to be shown it is done in the _last_ window.

To describe with a screenshot, the window `d` is the _last_ window:
<img width="1440" alt="Screenshot 2020-10-24 at 15 41 18" src="https://user-images.githubusercontent.com/815559/97084813-5dddbc80-1611-11eb-8fa1-2cd1b56e65bf.png">

- When the value is `'below` and a helm command is invoked from window -> the `helm-buffer` ends up in window:
  - `a` -> `s`
  - `s` -> `d`
  - `d` -> `d`

- When the value is `'other` and a helm command is invoked from window -> the `helm-buffer` ends up in window:
  - `a` -> `s`
  - `s` -> `d`
  - `d` -> `a`

I've also checked the `helm-split-window-default-side` which works even more consistently always splitting the current window, but I found the window to become very small (i.e., when called from an `s` window or a `d` window).