### PR TITLE
Workaround `electric-pair` and `iedit` interference issue

### DIFF
--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -20,10 +20,11 @@
 
 
 ;;; IEdit: rename the symbol under point
-;;; Fix A bug (normal key is "C-;")
 (use-package iedit
   :init
-  (define-key global-map (kbd "C-c ;") 'iedit-mode))
+  ;;; Fix A bug (normal key is "C-;")
+  :bind (:map global-map
+              ("C-c ;" . #'iedit-mode)))
 
 ;;; Don't show the abbrev minor mode in the mode line
 (diminish 'abbrev-mode)


### PR DESCRIPTION
The issue is described in https://github.com/victorhge/iedit/issues/114.

For now I got that the `electric-pair-inhibit-if-helps-balance` [has been updated in Emacs 27](https://github.com/emacs-mirror/emacs/commit/e66d5a1) and that causes issue to appear.

I'd love to create a proper fix, however, I haven't time yet to devise a one. The sheer size of `electric-pair` and `iedit` packages (especially their state and workarounds for different things in them) is just too much for me to consume at the moment. Perhaps the real solution would be to implement the `FIXME` added in the aforementioned commit?

Yet the issue happens often enough, that I wanted to do something about it. I decided to sacrifice the _some markers position_ and get back to the _old_ way of doing doing things when in `iedit-mode`.