### PR TITLE
Refactor init-helm.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ project directory structure on the left side:
 
 Keybinding          | Description
 --------------------|----------------------------------------------------------
-<kbd>C-c e</kbd>    | Open the current directory.
-<kbd>C-c E</kbd>    | Open the current project (projectile).
+<kbd>C-c e</kbd>    | Toggle `treemacs` the current directory.
+<kbd>C-c E</kbd>    | Open a projectile project (with a selector).
 
 Treemacs displays the git status of files (added, modified, ignored etc.) using
 different faces.

--- a/modules/init-helm-projectile.el
+++ b/modules/init-helm-projectile.el
@@ -1,4 +1,3 @@
-;;;; Helm - see http://tuhdo.github.io/helm-intro.html
 ;;;; Projectile - see http://batsov.com/projectile/
 ;;;
 ;;; ----------------- -------------------------------------------------------
@@ -6,17 +5,19 @@
 ;;; ----------------- -------------------------------------------------------
 ;;; C-c p p           [Opt remap] Select project and open file with helm.
 ;;; C-c p f           [Opt remap] Open file with helm-projectile (current project).
-;;; C-c h             Open file with helm-projectile (current project).
-;;; C-c M-h           Same but first select the project.
-;;; or C-c H
 ;;; C-c p s g         Grep in project.
-;;;
-;;; C-h b             Describe keybindings using Helm.
-;;; C-S-s             Helm Swoop, a way of searching with Helm (try it!).
-;;; C-c e             Project Explorer: show the directory tree.
+;;; ... and many more under C-c p
+;;; C-c h             Open file with helm-projectile (current project).
+;;; C-c H             Same but first select the project.
+;;; or C-c M-h
+;;; C-c e             treemacs: toggle the directory tree.
+;;; C-c E             Open treemacs with a projectile project.
+;;; C-S-a             Search with Ag: in current projectile project. (see also`init-helm.el')
+;;; C-S-r             Search with ripgrep: in current projectile project. (see also`init-helm.el')
 
 (require 'init-prefs)
-(use-package helm)
+
+(use-package helm-rg)
 
 (use-package projectile
   :bind
@@ -28,18 +29,22 @@
   (projectile-mode))
 
 (use-package helm-projectile
+  :bind
+  (:map global-map
+        ("C-c h"   . #'helm-projectile)
+        ("C-c H"   . #'helm-projectile-switch-project)
+        ("C-c M-h" . #'helm-projectile-switch-project)
+        ("C-S-a"   . #'helm-projectile-ag)
+        ("C-S-r"   . #'helm-projectile-rg))
   :config
-  (global-set-key [(control c)(h)] (function helm-projectile))
-  (global-set-key [(control c)(H)] (function helm-projectile-switch-project))
-  (global-set-key [(control c)(meta h)] (function helm-projectile-switch-project))
   (when exordium-helm-everywhere
     (helm-projectile-on)))
 
-(use-package helm-swoop
-  :init
-  ;; C-S-s = helm-swoop
-  (define-key global-map [(control shift s)] (function helm-swoop)))
-(use-package treemacs-projectile)
+(use-package treemacs-projectile
+  :bind
+  (:map global-map
+        ("C-c e" . #'treemacs)
+        ("C-c E" . #'treemacs-projectile)))
 
 ;; Prevent Projectile from indexing the build directory.
 (when exordium-rtags-cmake-build-dir
@@ -48,52 +53,5 @@
     (when top-level
       (setq projectile-globally-ignored-directories
             (cons top-level projectile-globally-ignored-directories)))))
-
-
-;;; Do not show these files in helm buffer
-(add-to-list 'helm-boring-file-regexp-list "\\.tsk$")
-(add-to-list 'helm-boring-file-regexp-list "\\.log\\.")
-
-;; Use `recentf-list' instead of `file-name-history' in `helm-find-files'.
-;;(setq helm-ff-file-name-history-use-recentf t)
-
-
-;;; Other usages of Helm:
-
-;;; C-h b = describe keybindings using Helm
-(use-package helm-descbinds
-  :init
-  (define-key global-map [(control h)(b)] (function helm-descbinds)))
-
-;; TODO: work in progress
-;; The intent is to improve the readability of the helm swoop selection line
-;; (in the helm buffer).
-
-;; (defun fix-helm-swoop-colors (orig-fun &rest args)
-;;   "Advice around `helm-swoop' to change the background of the
-;; selected line in the hem buffer, for better readability"
-;;   (let ((bg       (face-attribute 'helm-selection :background))
-;;         (swoop-bg (face-attribute 'helm-swoop-target-line-face :background)))
-;;     (set-face-attribute 'helm-selection nil :background swoop-bg)
-;;     (let ((res (apply orig-fun args)))
-;;       (set-face-attribute 'helm-selection nil :background bg)
-;;       res)))
-
-;; (advice-add 'helm-swoop :around #'fix-helm-swoop-colors)
-
-
-;;; Use fuzzy matching for helm-projectile when requested
-(when exordium-helm-fuzzy-match
-  (setq helm-projectile-fuzzy-match t))
-
-
-;;; File explorer (treemacs)
-
-;;; C-c e = Open treemacs in the current directory
-;;; C-c E = Open treemacs in the current projectile project
-(define-key global-map [(control c)(e)] (function treemacs))
-(define-key global-map [(control c)(E)] (function treemacs-projectile))
-
-
 
 (provide 'init-helm-projectile)

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -7,39 +7,104 @@
 ;;; M-y               Remap standard: Yank with helm.
 ;;; C-x b             Remap standard: Switch buffer with helm.
 ;;; C-x C-f           Remap standard: Find file with helm.
-;;; C-S-r             Search with ripgrep: in current projectile project.
+;;; C-x C-r           Open recent file with Helm (see also `init-ido.el').
+;;; C-h b             Describe keybindings using Helm.
+;;; C-S-r             Search with ripgrep: in current project root. (see also`init-helm-porojectile.el')
 ;;; C-S-d             Search with Ag: ask for directory first.
 ;;; C-S-f             Search with Ag: this file (like Swoop).
-;;; C-S-a             Search with Ag: in current projectile project.
+;;; C-S-a             Search with Ag: in current project root. (see also`init-helm-porojectile.el')
+;;; C-S-s             Helm Swoop
+
+(require 'init-prefs)
 
 (use-package helm
+  :diminish helm-mode
   :custom
-  (helm-split-window-default-side 'other))
-(use-package helm-projectile)
-(use-package helm-ag)
-(use-package helm-rg)
+  (helm-split-window-default-side 'other)
+  (helm-buffer-details-flag nil)
+
+  :config
+  (when exordium-helm-fuzzy-match
+    ;; following advice from `helm-completion-style' doc
+    (let ((style (or
+                  (car (assq 'flex completion-styles-alist))
+                  (car (assq 'helm-flex completion-styles-alist)))))
+      (if style
+          (add-to-list 'completion-styles style)
+        (customize-set-variable 'helm-completion-style 'helm-fuzzy)))))
+
+(use-package helm
+  :diminish helm-mode
+  :when exordium-helm-everywhere
+  :custom
+  (history-delete-duplicates t)
+  (helm-M-x-always-save-history t)
+  :bind
+  (:map global-map
+        ([remap execute-extended-command] . #'helm-M-x) ; M-x
+        ([remap yank-pop] . #'helm-show-kill-ring) ; M-y
+        ([remap find-file] . #'helm-find-files) ; C-x C-f
+        ([remap find-file-read-only] . #'helm-recentf)) ; C-x C-r
+  :config
+  ;; Do not show these files in helm buffer
+  (add-to-list 'helm-boring-file-regexp-list "\\.tsk$")
+  (add-to-list 'helm-boring-file-regexp-list "\\.log\\.")
+  (helm-mode))
+
+(use-package helm-descbinds
+  :bind
+  (:map global-map
+         ("C-h b". #'helm-descbinds)))
+
+(use-package helm-ag
+  :custom
+  (helm-ag-insert-at-point 'symbol)
+  :bind
+  (:map global-map
+        ("C-S-d" . #'helm-do-ag)
+        ("C-S-f" . #'helm-do-ag-this-file)))
+
+(use-package helm-ag
+  :unless exordium-helm-projectile
+  :bind
+  (:map global-map
+        ("C-S-a" . #'helm-ag-project-root)))
+
+(use-package helm-rg
+  :unless exordium-helm-projectile
+  :bind
+  (:map global-map
+        ("C-S-r" . #'helm-rg)))
+
+(use-package helm-swoop
+  :bind
+  (:map global-map
+        ("C-S-s" . #'helm-swoop)
+   ;; Use similar bindings to `helm-ag-edit'
+   :map helm-swoop-edit-map
+        ("C-c C-c" . #'helm-swoop--edit-complete)
+        ("C-c C-k" . #'helm-swoop--edit-cancel)
+        ("C-c C-q C-k" . #'helm-swoop--edit-delete-all-lines)))
+
 
 
-(global-set-key (kbd "C-S-r")   'helm-projectile-rg)
-(global-set-key (kbd "C-S-d")   'helm-do-ag)
-(global-set-key (kbd "C-S-f")   'helm-do-ag-this-file)
-(global-set-key (kbd "C-S-a")   'helm-projectile-ag)
 
-(when exordium-helm-everywhere
-  (helm-mode)
-  (diminish 'helm-mode)
-  (global-set-key (kbd "M-x") 'helm-M-x)
-  (global-set-key (kbd "C-x C-f") 'helm-find-files)
-  (global-set-key (kbd "M-y") 'helm-show-kill-ring))
+;; TODO: work in progress
+;; The intent is to improve the readability of the helm swoop selection line
+;; (in the helm buffer).
 
-(when exordium-helm-fuzzy-match
-  (setq helm-M-x-fuzzy-match t
-        helm-buffers-fuzzy-matching t
-        helm-recentf-fuzzy-match t
-        helm-ff-fuzzy-matching t
-        helm-ag-fuzzy-match t
-        helm-buffer-details-flag nil
-        helm-ag-insert-at-point 'symbol))
+;; (defun fix-helm-swoop-colors (orig-fun &rest args)
+;;   "Advice around `helm-swoop' to change the background of the
+;; selected line in the hem buffer, for better readability"
+;;   (let ((bg       (face-attribute 'helm-selection :background))
+;;         (swoop-bg (face-attribute 'helm-swoop-target-line-face :background)))
+;;     (set-face-attribute 'helm-selection nil :background swoop-bg)
+;;     (let ((res (apply orig-fun args)))
+;;       (set-face-attribute 'helm-selection nil :background bg)
+;;       res)))
+
+;; (advice-add 'helm-swoop :around #'fix-helm-swoop-colors)
 
 
+
 (provide 'init-helm)

--- a/modules/init-ido.el
+++ b/modules/init-ido.el
@@ -3,7 +3,7 @@
 ;;; -------------- -------------------------------------------------------
 ;;; Key            Definition
 ;;; -------------- -------------------------------------------------------
-;;; C-x C-r        Open recent file with IDO or Helm.
+;;; C-x C-r        Open recent file with IDO (see also `init-helm.el').
 
 (use-package ido
   :if (not exordium-helm-everywhere)
@@ -37,7 +37,6 @@
 ;; `abbreviate-file-name' abbreviates home dir to ~/ in the file list
 ;; Custom abbreviations can be added to `directory-abbrev-alist'.
 (use-package recentf)
-(use-package helm)
 
 (recentf-mode 1)
 (setq recentf-max-menu-items 25)
@@ -53,10 +52,9 @@
    (ido-completing-read "Recentf open: "
                         (mapcar 'abbreviate-file-name recentf-list)
                         nil t)))
-(cond (exordium-helm-everywhere
-       (define-key global-map [(control x)(control r)] 'helm-recentf))
-      (t
-       (define-key global-map [(control x)(control r)] 'ido-find-recentf)))
+
+(unless exordium-helm-everywhere
+  (define-key global-map [(control x)(control r)] 'ido-find-recentf))
 
 
 (provide 'init-ido)

--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -128,7 +128,7 @@
 (use-package rtags)
 (use-package ac-rtags)
 (use-package auto-complete-c-headers)
-(use-package projectile)
+;;(use-package projectile)
 (use-package company-rtags)
 
 ;;; Turn on flycheck support when requested


### PR DESCRIPTION
Move most of `helm` related stuff into `init-helm` and only left `projectile`, `helm-projectile`, and `treemacs` in `helm-projectile`. It changes semantics a bit, since now `helm-swoop`, `helm-ag`, and `helm-rg` will be always loaded, albeit bindings will point to different functions depending on `exordium-helm-projectile`.

It also changes how the completion works. Recent `helm` seem to advise to use
the `completion-styles` now to configure this globally. So I removed all
variables that were pointing to some kind of  /fuzzy/ completion mode, and use
`flex` instead.

I've also changed bindings in `helm-swoop-edit-mode` to follow these from
`helm-ag` - after all `C-c C-c` to accept and `C-c C-k` to cancel are the same
as in `magit`.

The `:diminish` has to be done twice as the second load will enable lighter 🤷‍♂️.