### PR TITLE
Don't enable line numbers if mode is inherited from exordium-inhibit-line-numbers-modes

### DIFF
--- a/modules/init-linum.el
+++ b/modules/init-linum.el
@@ -30,7 +30,9 @@
 (defun exordium-inhibit-line-numbers-p ()
   (or (minibufferp)
       (and exordium-inhibit-line-numbers-modes
-           (cl-member major-mode exordium-inhibit-line-numbers-modes))
+           (cl-find-if #'(lambda (mode)
+                           (derived-mode-p mode))
+                       exordium-inhibit-line-numbers-modes))
       (and exordium-inhibit-line-numbers-star-buffers
            (eq 0 (string-match "*" (buffer-name))))
       (and exordium-inhibit-line-numbers-buffer-size

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -138,20 +138,21 @@ line numbers WILL NOT be shown."
   :group 'exordium
   :type  'symbol)
 
-(defcustom exordium-inhibit-line-numbers-modes '(eshell-mode
-                                                 shell-mode
-                                                 help-mode
-                                                 compilation-mode
-                                                 iwyu-mode
-                                                 Info-mode
+(defcustom exordium-inhibit-line-numbers-modes '(Info-mode
                                                  calendar-mode
-                                                 treemacs-mode
-                                                 org-mode
-                                                 rtags-rdm-mode
-                                                 rtags-diagnostics-mode
-                                                 eww-mode
+                                                 compilation-mode
                                                  dired-mode
-                                                 image-mode)
+                                                 eshell-mode
+                                                 eww-mode
+                                                 help-mode
+                                                 image-mode
+                                                 iwyu-mode
+                                                 magit-mode
+                                                 org-mode
+                                                 rtags-diagnostics-mode
+                                                 rtags-rdm-mode
+                                                 shell-mode
+                                                 treemacs-mode)
   "List of modes for which line numbers should not be displayed."
   :group 'exordium
   :type 'list)


### PR DESCRIPTION
Also add `magit-mode` to the list. I didn't find usefulness of line numbers in `magit` buffers like status, log, commit preview, etc. On the other hand it can make emacs even slower when opening a commit with large diff inside. Happy to remove if it is useful by default.