### PR TITLE
Add init-forge with markdown-preview and draft PR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ might want to check these links:
 * Projects: [Projectile](http://batsov.com/projectile) (project-based file
   management tool).
 * Git: [Magit](http://magit.vc) (git UI);
+  [Forge](https://magit.vc/manual/forge/) (work with Git forges);
   [Git Gutter](https://github.com/syohex/emacs-git-gutter) (diffs in buffer).
 * C++:
   * [RTags](https://github.com/Andersbakken/rtags): a LLVM/Clang-based code
@@ -372,6 +373,15 @@ Keybinding            | Description
 <kbd>C-c g b</kbd>    | Toggles git blame mode on and off (`magit-blame-mode`).
 <kbd>C-c g c</kbd>    | Clone a repository (`magit-clone`).
 <kbd>C-c g g</kbd>    | Git grep (`vc-git-grep`) or (`helm-grep-do-git-grep`).
+
+Forge keys:
+
+Keybinding            | Description
+----------------------|-----------------------------------------------------------
+<kbd>C-c C-p</kbd>    | in `forge-post-mode`: Preview post with markdown (`exordium-forge-markdown-preview`)
+<kbd>C-c C-d</kbd>    | in `forge-post-mode`: Submit current post (a Pull Request) as a draft (`exordium-forge-post-submit-draft`)
+<kbd>C-c C-d</kbd>    | in `magit-status-mode` and in `forge-topic-mode`: Mark a Pull Request at point as ready for review (`exordium-forge-mark-ready-for-rewiew`)
+
 
 Git gutter keys:
 

--- a/init.el
+++ b/init.el
@@ -270,6 +270,7 @@ the .elc exists. Also discard .elc without corresponding .el"
 (use-package init-dired :ensure nil)           ; enable dired+ and wdired permission editing
 (use-package init-git :ensure nil)             ; Magit and git gutter
 (use-package init-git-visit-diffs :ensure nil) ; visit diffs in successive narrowed buffers
+(use-package init-forge :ensure nil)           ; Forge
 (use-package init-flb-mode :ensure nil)        ; frame-local buffers
 
 (update-progress-bar)

--- a/modules/init-forge.el
+++ b/modules/init-forge.el
@@ -4,7 +4,7 @@
 ;;; Key               Definition
 ;;; ----------------- ---------------------------------------------------------
 ;;; C-c C-p           Markdown preview (in `forge-post-mode')
-;;; C-c C-d           Forge post submint as draft (in `forge-post-mode')
+;;; C-c C-d           Forge post submit as draft (in `forge-post-mode')
 ;;; C-c C-d           Forge mark pull request at point mark as ready for review
 ;;;                   (in `magit-status-mode' and in `forge-topic-mode')
 
@@ -16,7 +16,7 @@
   :init
 
   (defun exordium-forge-markdown-preview ()
-    "Preview current buffer as a preview in a `markdown-mode' would do."
+    "Preview current buffer as a preview in a `markdown-mode' buffer would do."
     (interactive)
     (let ((temp-file (make-temp-file (file-name-base buffer-file-name)
                                      nil ".md"

--- a/modules/init-forge.el
+++ b/modules/init-forge.el
@@ -83,6 +83,7 @@ USERNAME, AUTH, and HOST behave as for `ghub-request'."
              (_ (string-match
                  "//\\([^/]+\\)/\\([^/]+\\)/\\([^/]+\\)/pull/\\([0-9]+\\)$"
                  url))
+             (number (match-string 4 url))
              (host (car (alist-get (match-string 1 url)
                                    forge-alist
                                    nil nil #'string=)))
@@ -91,13 +92,13 @@ USERNAME, AUTH, and HOST behave as for `ghub-request'."
              (id (exordium-ghub-graphql--pull-request-id
                   (match-string 2 url)
                   (match-string 3 url)
-                  (string-to-number (match-string 4 url))
+                  (string-to-number number)
                   :username username :auth 'forge :host host))
              (not-a-draft-anymore
               (not (exordium-ghub-grqphql--mark-pull-request-ready-for-review
                     id
                     :username username :auth 'forge :host host))))
-        (message "PR #%s marked as ready for review." (match-string 4 url))
+        (message "PR #%s is ready for review." number)
       (user-error "Nothing at point that is a PR or mark failed")))
   :hook
   (forge-post-mode . (lambda ()

--- a/modules/init-forge.el
+++ b/modules/init-forge.el
@@ -1,0 +1,115 @@
+;;;; Forge - work with Git forges Magit
+;;;
+;;; ----------------- ---------------------------------------------------------
+;;; Key               Definition
+;;; ----------------- ---------------------------------------------------------
+;;; C-c C-p           Markdown preview (in `forge-post-mode')
+;;; C-c C-d           Forge post submint as draft (in `forge-post-mode')
+;;; C-c C-d           Forge mark pull request at point mark as ready for review
+;;;                   (in `magit-status-mode' and in `forge-topic-mode')
+
+
+
+;;; Magit Forge
+(use-package forge
+  :defer t
+  :init
+
+  (defun exordium-forge-markdown-preview ()
+    "Preview current buffer as a preview in a `markdown-mode' would do."
+    (interactive)
+    (let ((temp-file (make-temp-file (file-name-base buffer-file-name)
+                                     nil ".md"
+                                     (buffer-string))))
+      (with-temp-buffer
+        (insert-file-contents temp-file t)
+        (markdown-preview))
+      (delete-file temp-file)))
+  
+
+  (defun exordium-forge--add-draft (alist)
+    "Add draft to ALIST."
+    (append alist '((draft . "t"))))
+
+  (defun exordium-forge-post-submit-draft ()
+    "Submit the post that is being edited in the current buffer as a draft.
+This relies on implementation of `forge--topic-parse-buffer', that requires
+a key `draft' to have a value of t."
+    (interactive)
+    (advice-add 'forge--topic-parse-buffer
+                :filter-return #'exordium-forge--add-draft)
+    (condition-case err
+        (forge-post-submit)
+      (t
+       (advice-remove 'forge--topic-parse-buffer #'exordium-forge--add-draft)
+       (signal (car err) (cdr err))))
+    (advice-remove 'forge--topic-parse-buffer #'exordium-forge--add-draft))
+
+  (cl-defun exordium-ghub-graphql--pull-request-id
+      (owner name number &key username auth host)
+    "Return the id of the PR specified by OWNER, NAME, and NUMBER.
+USERNAME, AUTH, and HOST behave as for `ghub-request'."
+    (let-alist (ghub-graphql
+                "query($owner:String!, $name:String!, $number:Int!) {
+                 repository(owner:$owner, name:$name) {
+                   pullRequest(number:$number) { id }}}"
+                `((owner . ,owner)
+                  (name . ,name)
+                  (number . ,number))
+                :username username :auth auth :host host)
+      .data.repository.pullRequest.id))
+
+  (cl-defun exordium-ghub-grqphql--mark-pull-request-ready-for-review
+      (id &key username auth host)
+    "Mark the pull request with the specified ID as ready for review.
+Return t if pull request is a draft.  Return nil otherwise.
+USERNAME, AUTH, and HOST behave as for `ghub-request'."
+    (let-alist (ghub-graphql
+                "mutation($id:String!) {
+                   markPullRequestReadyForReview(input:{pullRequestId:$id}) {
+                     pullRequest { isDraft }}}"
+                `((id . ,id))
+                :username username :auth auth :host host
+                ;; because of GHE 2.20
+                :headers '(("Accept" .
+                            "application/vnd.github.shadow-cat-preview+json")))
+      .data.markPullRequestReadyForReview.pullRequest.isDraft))
+
+  (defun exordium-forge-mark-ready-for-rewiew ()
+    "Mark the thing (the PR) at point as ready for review."
+    (interactive)
+    (if-let ((url (forge-get-url (or (forge-post-at-point)
+                                     (forge-current-topic))))
+             (_ (string-match
+                 "//\\([^/]+\\)/\\([^/]+\\)/\\([^/]+\\)/pull/\\([0-9]+\\)$"
+                 url))
+             (host (car (alist-get (match-string 1 url)
+                                   forge-alist
+                                   nil nil #'string=)))
+             (username (magit-git-string "config"
+                                         (concat "github." host ".user")))
+             (id (exordium-ghub-graphql--pull-request-id
+                  (match-string 2 url)
+                  (match-string 3 url)
+                  (string-to-number (match-string 4 url))
+                  :username username :auth 'forge :host host))
+             (not-a-draft-anymore
+              (not (exordium-ghub-grqphql--mark-pull-request-ready-for-review
+                    id
+                    :username username :auth 'forge :host host))))
+        (message "PR #%s marked as ready for review." (match-string 4 url))
+      (user-error "Nothing at point that is a PR or mark failed")))
+  :hook
+  (forge-post-mode . (lambda ()
+                       (set-fill-column 1000)))
+  :bind
+  (:map forge-post-mode-map
+        ("C-c C-p" . #'exordium-forge-markdown-preview)
+        ("C-c C-d" . #'exordium-forge-post-submit-draft)
+   :map magit-status-mode-map
+        ("C-c C-d" . #'exordium-forge-mark-ready-for-rewiew)
+   :map forge-topic-mode-map
+        ("C-c C-d" . #'exordium-forge-mark-ready-for-rewiew)))
+
+
+(provide 'init-forge)

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -1,4 +1,4 @@
-;;;; All git-related stuff
+;;;; All git-related stuff, except for forge
 ;;;
 ;;; All keys are C-c g <one-more-key>:
 ;;;


### PR DESCRIPTION
Move forge into it's own `init-forge.el` file and add some extra support:
- `markdown-preview` function - that requires the `markdown-preview` to work in regular `markdown-mode` buffers.
- draft Pull Request submission and marking as Ready for Review; unfortunately I haven't been able to add support for displaying status of these; probably something in a `forge-topic-mode` and in a `magit-status-mode` but that would likely require to update `forge-db`, so will likely have to come from upstream.

I've chosen to overload `C-c C-d` for draft Pull Request submission and marking as ready for review. Hopefully you'll like this.

To validate this: I'm previewing text of this PR, then submitting it as a draft followed by marking as ready for review. What a nice workflow 😎.

Please note that this PR requires fairly recent version of `ghub` so the `ghub-graphql` function supports `:headers` key argument (already available on melpa).