### PR TITLE
Add help extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ might want to check these links:
   (80-character column marker);
   [Treemacs](https://github.com/Alexander-Miller/treemacs) (directory tree);
   [Avy](https://github.com/abo-abo/avy) (jump to visible text in 2 or 3 key-strokes);
-  [ace-window](https://github.com/abo-abo/ace-window) (quick jump between windows).
+  [ace-window](https://github.com/abo-abo/ace-window) (quick jump between windows);
+  [helpful](https://github.com/Wilfred/helpful) (a better Emacs *help* buffer);
+  [which-key](https://github.com/justbur/emacs-which-key) (display available keybindings).
 * Projects: [Projectile](http://batsov.com/projectile) (project-based file
   management tool).
 * Git: [Magit](http://magit.vc) (git UI);

--- a/init.el
+++ b/init.el
@@ -265,6 +265,9 @@ the .elc exists. Also discard .elc without corresponding .el"
   :if exordium-helm-projectile)
 (use-package init-helm :ensure nil)            ; setup helm
 
+(use-package init-help :ensure nil
+  :if exordium-help-extensions)
+
 (update-progress-bar)
 
 (use-package init-dired :ensure nil)           ; enable dired+ and wdired permission editing

--- a/modules/init-elisp.el
+++ b/modules/init-elisp.el
@@ -9,7 +9,8 @@
 ;;; Display page breaks with an horizontal line instead of ^L.
 ;;; Note: To insert a page break: C-q C-l
 ;;;       To jump to the previous/next page break: C-x [ and C-x ]
-(use-package page-break-lines)
+(use-package page-break-lines
+  :diminish)
 
 ;;; Animation when evaluating a defun or a region:
 (use-package highlight)
@@ -20,8 +21,7 @@
 enables line truncation as well to prevent a rendering bug (page
 break lines wrap around)."
   (set (make-local-variable 'truncate-lines) t)
-  (turn-on-page-break-lines-mode)
-  (diminish 'page-break-lines-mode))
+  (turn-on-page-break-lines-mode))
 
 (add-hook 'emacs-lisp-mode-hook #'exordium-elisp-mode-hook)
 

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -18,7 +18,7 @@
 (require 'init-prefs)
 
 (use-package helm
-  :diminish helm-mode
+  :diminish
   :custom
   (helm-split-window-default-side 'other)
   (helm-buffer-details-flag nil)
@@ -34,7 +34,7 @@
         (customize-set-variable 'helm-completion-style 'helm-fuzzy)))))
 
 (use-package helm
-  :diminish helm-mode
+  :diminish
   :when exordium-helm-everywhere
   :custom
   (history-delete-duplicates t)

--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -30,7 +30,9 @@
 
 
 (use-package page-break-lines
-  :diminish)
+  :diminish
+  :hook
+  (help-mode . page-break-lines-mode))
 
 (use-package helpful
   :bind
@@ -54,9 +56,7 @@
    :map emacs-lisp-mode-map
         ("C-c C-d" . #'helpful-at-point)
    :map helpful-mode-map
-        ("C-c C-o" . #'exordium-browse-url-at-point))
-  :hook
-  (help-mode . turn-on-page-break-mode))
+        ("C-c C-o" . #'exordium-browse-url-at-point)))
 
 (use-package helm
   :diminish

--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -1,0 +1,68 @@
+;;;; Help extensions
+;;;
+;;; ----------------- ---------------------------------------------------------
+;;; Key               Definition
+;;; ----------------- ---------------------------------------------------------
+;;; C-c C-o           Open URL at point (in `help-mode' and `helpful-mode')
+;;; C-h f             Show help for function, macro or special form
+;;; C-h F             Show help for function
+;;; C-h v             Show help for variable
+;;; C-h k             Show help for interactive command bound to key sequence
+;;; C-h C             Show help for interactive command
+;;; C-c C-d           Show help for thing at point (in `emacs-lisp-mode')
+
+
+;;; Which Key - display available keybindings in popup.
+(use-package which-key
+  :diminish
+  :config
+  (which-key-mode))
+
+
+;; Tune keys in `help-mode' - i.e., works when reading package information in
+;; `package-list-packages'.
+
+(use-package help-mode
+  :ensure nil
+  :bind
+  (:map help-mode-map
+        ("C-c C-o" . #'exordium-browse-url-at-point)))
+
+
+(use-package page-break-lines
+  :diminish)
+
+(use-package helpful
+  :bind
+  (:map global-map
+        ;; Note that the built-in `describe-function' includes both functions
+        ;; and macros. `helpful-function' is functions only, so we provide
+        ;; `helpful-callable' as a drop-in replacement.
+        ("C-h f" . #'helpful-callable)
+        ;; Look up *F*unctions (excludes macros).
+        ;; By default, C-h F is bound to `Info-goto-emacs-command-node'. Helpful
+        ;; already links to the manual, if a function is referenced there.
+        ("C-h F" . #'helpful-function)
+        ("C-h v" . #'helpful-variable)
+        ("C-h k" . #'helpful-key)
+        ;; Look up *C*ommands.
+        ;; By default, C-h C is bound to describe `describe-coding-system'.
+        ;; Apparently it's frequently useful to only look at interactive functions.
+        ("C-h C" . #'helpful-command)
+        ;; Lookup the current symbol at point. C-c C-d is a common keybinding
+        ;; for this in lisp modes.
+   :map emacs-lisp-mode-map
+        ("C-c C-d" . #'helpful-at-point)
+   :map helpful-mode-map
+        ("C-c C-o" . #'exordium-browse-url-at-point))
+  :hook
+  (help-mode . turn-on-page-break-mode))
+
+(use-package helm
+  :diminish
+  :custom
+  (helm-describe-variable-function #'helpful-variable)
+  (helm-describe-function-function #'helpful-function))
+
+
+(provide 'init-help)

--- a/modules/init-lib.el
+++ b/modules/init-lib.el
@@ -94,4 +94,11 @@ attention to case differences."
                 (append electric-pair-text-pairs '((?` . ?`))))))
 
 
+(defun exordium-browse-url-at-point ()
+  "Open an URL at point."
+  (interactive)
+  (when-let ((url (thing-at-point 'url)))
+    (browse-url url)))
+
+
 (provide 'init-lib)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -122,6 +122,11 @@ The original window configuration will be restored when you quit out of magit."
   :group 'exordium
   :type  'boolean)
 
+(defcustom exordium-help-extensions t
+  "If t, use help extensions like `which-key' and `helpful-mode'."
+  :group 'exordium
+  :type 'boolean)
+
 
 ;;; Line numbers - see init-linum.el
 


### PR DESCRIPTION
Add `helpful` and `which-key` as well as add `C-c C-o` keybinding in `help-mode`.

I've been using `helpful` for over 2 years now.  I think they are both really useful, hence I took a liberty and enabled that by default.

Over the course of 2 years I've extended the setup a bit (like hooking up into helm, but not fully yet, due to a [lack of support in `helm-descbinds`](https://github.com/emacs-helm/helm-descbinds/pull/30).

I really got to liking `C-c C-o` when working with `magit` and `forge` and I was missing this a lot when reading help for a function or a variable or a synopsis of some package (in `package-list-packages`).

Perhaps a window management could be improved so it doesn't clobber all available windows when digging deeper and deeper in a help links, but I leave it out for a time when I get to understanding how I really would like to use that. Perhaps, if you use it a bit you could come up with ideas how it should behave.