### PR TITLE
Make sure flyspell is loaded when adding the prog-mode-hook

### DIFF
--- a/modules/init-prog-mode.el
+++ b/modules/init-prog-mode.el
@@ -24,9 +24,6 @@
   :init
   (add-hook 'prog-mode-hook 'flyspell-prog-mode))
 
-(when (eq exordium-spell-check :prog)
-  (add-hook 'prog-mode-hook 'flyspell-prog-mode))
-
 
 ;;; Electric pair: automatically close parenthesis, curly brace etc.
 ;;; `electric-pair-open-newline-between-pairs'.

--- a/modules/init-prog-mode.el
+++ b/modules/init-prog-mode.el
@@ -18,6 +18,12 @@
 (add-hook 'prog-mode-hook 'exordium-show-trailing-whitespace-mode)
 (add-hook 'prog-mode-hook 'exordium-require-final-newline-mode)
 
+(use-package flyspell
+  :if (eq exordium-spell-check :prog)
+  :diminish 'flyspell-mode
+  :init
+  (add-hook 'prog-mode-hook 'flyspell-prog-mode))
+
 (when (eq exordium-spell-check :prog)
   (add-hook 'prog-mode-hook 'flyspell-prog-mode))
 


### PR DESCRIPTION
Make sure the flyspell package is loaded and configured if using
flyspell-prog-mode as a prog-mode-hook.


----

#