### PR TITLE
Refactor helm-flycheck

### DIFF
--- a/modules/init-rtags-helm.el
+++ b/modules/init-rtags-helm.el
@@ -5,25 +5,34 @@
 ;;; -------------- -------------------------------------------------------
 ;;; M-C-g          `rtags-helm-select-taglist' = select a symbol in the
 ;;;                current file using Helm.
-;;; C-c r r        `helm-flycheck' show rtags errors in helm buffer
+;;; C-c r r        `helm-flycheck' show rtags & flycheck errors in helm buffer
+;;;                when buffer is in `c-mode'
+;;; C-x c f        `helm-flycheck' show flycheck errors in helm buffer
 ;;; -------------- -------------------------------------------------------
 
 (use-package rtags)
 (use-package helm)
 (use-package helm-rtags)
+(use-package flycheck)
+(use-package cc-mode :ensure nil)
 (require 'init-prefs)
+
+(defun exordium-helm-flycheck ()
+  "Ensure `flycheck-mode' is enabled and run `helm-flycheck'."
+  (interactive)
+  (unless flycheck-mode
+    (flycheck-mode)
+    (diminish 'flycheck-mode))
+  (helm-flycheck))
 
 (use-package helm-flycheck
   :if (eq exordium-rtags-syntax-checker :flycheck)
-  :init
-  (define-key c-mode-base-map
-    (kbd "C-c r r")
-    (lambda ()
-      (interactive)
-      (unless flycheck-mode
-        (flycheck-mode)
-        (diminish 'flycheck-mode))
-      (helm-flycheck))))
+  :bind
+  (:map c-mode-base-map
+        ("C-c r r" . #'exordium-helm-flycheck)
+   :map helm-command-map
+   ("f" . #'exordium-helm-flycheck)))
+
 
 (defcustom rtags-helm-show-variables nil
   "Whether `rtags-helm-select-taglist' shows variables and parameters"

--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -136,13 +136,14 @@
   :if (eq exordium-rtags-syntax-checker :flycheck)
   :init
   ;; As per: https://github.com/Andersbakken/rtags#rtags-flycheck-integration
-  (cl-flet ((flycheck-rtags-hook ()
-                                 (flycheck-select-checker 'rtags)
-                                 (setq-local flycheck-highlighting-mode nil)
-                                 (setq-local flycheck-check-syntax-automatically nil))))
-  (add-hook 'c-mode-hook #'flycheck-rtags-hook)
-  (add-hook 'c++-mode-hook #'flycheck-rtags-hook)
-  (add-hook 'objc-mode-hook #'flycheck-rtags-hook))
+  (defun exordium--setup-flycheck-rtags ()
+    (flycheck-select-checker 'rtags)
+    (setq-local flycheck-highlighting-mode nil)
+    (setq-local flycheck-check-syntax-automatically nil))
+  :hook
+  (c-mode . exordium--setup-flycheck-rtags)
+  (c++-mode . exordium--setup-flycheck-rtags)
+  (objc-mode . exordium--setup-flycheck-rtags))
 
 ;;; Key bindings
 


### PR DESCRIPTION
- Add missing packages, so it compiles without errors.
- Use `:bind` so the binding is defferred to a moment the map is defines.
- Add extra binding to `helm-command-map` (`C-x c f`):
  - It overrides `helm-multi-files` - I've never used that, but if you do, I'm happy to use a different binding. Suggestions?
- Update `flycheck-rtags` to use regular function for a hook, so it has no problems when running tests in `init-bde-style.t.el`.