### PR TITLE
Revert "Disable cmake-mode on emacs-26"

### DIFF
--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -174,9 +174,6 @@
   :hook (c++-mode . modern-c++-font-lock-mode))
 
 (use-package cmake-mode
-  ;; Temporarily disable cmake-mode on emacs-26 until the following fix is in melpa
-  ;; https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5657
-  :no-require (version< emacs-version "27")
   :mode (("/CMakeLists\\.txt\\'" . cmake-mode)
          ("\\.cmake\\'" . cmake-mode)))
 


### PR DESCRIPTION
The fix for `cmake-mode` has been merged. Let's see if this passes CI.

This reverts commit f7f003b0aa228d6ffc96229d106288d494c89cdb.