### PR TITLE
Refactor init-lisp

### DIFF
--- a/modules/init-elisp.el
+++ b/modules/init-elisp.el
@@ -5,24 +5,25 @@
 
 ;;; Bind M-C-g to helm-imenu (lists functions and variables in buffer)
 (define-key emacs-lisp-mode-map [(meta control g)] 'helm-imenu)
+
+(defun exordium-page-break-lines-hook ()
+  "Enable `page-break-lines' mode.
+When in TUI enable line truncation as well to prevent a rendering
+bug (page break lines wrap around)."
+  (unless (display-graphic-p)
+    (set (make-local-variable 'truncate-lines) t))
+  (page-break-lines-mode))
 
 ;;; Display page breaks with an horizontal line instead of ^L.
 ;;; Note: To insert a page break: C-q C-l
 ;;;       To jump to the previous/next page break: C-x [ and C-x ]
 (use-package page-break-lines
-  :diminish)
-
+  :diminish
+  :hook
+  (emacs-lisp-mode . exordium-page-break-lines-hook))
+
 ;;; Animation when evaluating a defun or a region:
 (use-package highlight)
 (use-package eval-sexp-fu)
-
-(defun exordium-elisp-mode-hook ()
-  "Hook for elisp mode. Enables `page-break-lines' mode and
-enables line truncation as well to prevent a rendering bug (page
-break lines wrap around)."
-  (set (make-local-variable 'truncate-lines) t)
-  (turn-on-page-break-lines-mode))
-
-(add-hook 'emacs-lisp-mode-hook #'exordium-elisp-mode-hook)
-
+
 (provide 'init-elisp)


### PR DESCRIPTION
This is to only register hook after the `use-package` to avoid issues first
start when packages are downloaded, like here: https://github.com/emacs-exordium/exordium/runs/1673475767