### PR TITLE
Add a transient dispatch for SMerge mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ might want to check these links:
 * [Keymap](#keymap)
 * [Projectile](#projectile)
 * [Git](#git)
+  * [Conflict Resolution](#conflict-resolution)
 * C++
   * [Utilities](#utilities)
   * [Snippets](#snippets)
@@ -400,6 +401,8 @@ Git Timemachine key   | Description
 ----------------------|-----------------------------------------------------------
 <kbd>C-c g t</kbd>    | Enter the git time machine (`git-timemachine-toggle`)
 
+### Conflict Resolution
+
 If you use `ediff` to solve merge conflicts you may find the following keys useful
 (in `*Ediff Control Panel*`):
 
@@ -407,6 +410,21 @@ ediff key             | Description
 ----------------------|-----------------------------------------------------------
 <kbd>A</kbd>          | Copy buffer A's region followed by buffer B's region to C
 <kbd>B</kbd>          | Copy buffer B's region followed by buffer A's region to C
+
+When the variable `exordium-smerge-show-dispatch` is set to `t` (the default) hitting `RET`
+on a file with unmerged changes in Magit status buffer will display a SMerge dispatch that
+will assist with merge using built-in `smerge-mode`. When all conflicts are resolved,
+hitting `C-c C-c` will bring you back to Magit status. Hitting `C-c C-k` will revert the buffer
+to last saved changes and will bring you back to Magit status.
+
+The SMerge dispatch is a `transient` command (like most of `magit` and `forge` commands), so it can
+always be dismissed with `C-g`.
+
+In addition to keys presented in the dispatch, the following keys are added to SMerge keys:
+
+Keybinding            | Description
+----------------------|-----------------------------------------------------------
+<kbd>C-c ^ d</kbd> | Show SMerge dispatch  (`exordium-smerge-dispatch`).
 
 ## C++
 

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -17,6 +17,8 @@
 ;;; C-c g p           Goto previous hunk in buffer
 ;;; C-c g d           Diff current hunk
 ;;; C-c g r           Revert current hunk (asks for confirmation)
+;;;
+;;; C-c ^ d           Show SMerge Dispatch
 
 ;;; Magit
 (define-prefix-command 'exordium-git-map nil)
@@ -94,7 +96,77 @@
 (when (bound-and-true-p magit-auto-revert-mode)
   (diminish 'magit-auto-revert-mode))
 
+
+;; SMerge Dispatch
+(defun exordium-smerge--save-and-status ()
+  "Save current buffer and show Magit status buffer."
+  (interactive)
+  (save-buffer)
+  (magit-status-setup-buffer))
 
+(defun exordium-smerge--revert-and-status ()
+  "Revert current buffer and run Magit status buffer."
+  (interactive)
+  (revert-buffer nil t)
+  (magit-status-setup-buffer))
+
+(transient-define-suffix exordium-smerge:undo ()
+  :description "undo"
+  :key (if exordium-keyboard-ctrl-z-undo "C-z" "C-x u")
+  (interactive)
+  (undo))
+
+;;;###autoload
+(define-transient-command exordium-smerge-dispatch ()
+  "Dispatch for `smerge-mode' commands."
+  :transient-suffix     'transient--do-stay
+  :transient-non-suffix 'transient--do-warn
+  [["Movement"
+    ("n" "next hunk" smerge-next)
+    ("p" "prev hunk" smerge-prev)
+    ("C-n" "next line" next-line)
+    ("C-p" "prev line" previous-line)
+    ("C-v" "scroll up" scroll-up-command)
+    ("M-v" "scroll down" scroll-down-command)
+    ("C-l" "recenter" recenter-top-bottom)]
+   ["Merge action"
+    ("b" "keep base" smerge-keep-base)
+    ("u" "keep upper" smerge-keep-upper)
+    ("l" "keep lower" smerge-keep-lower)
+    ("a" "keep all"   smerge-keep-all)
+    ("c" "keep current" smerge-keep-current)
+    ("r" "resolve" smerge-resolve)]
+   ["Diff action"
+    ("= <" "upper/base" smerge-diff-base-upper)
+    ("= =" "upper/lower" smerge-diff-upper-lower)
+    ("= >" "base/lower" smerge-diff-base-lower)
+    ("R" "refine" smerge-refine)
+    ("C" "combine with next" smerge-combine-with-next)
+    ("k" "kill current" smerge-kill-current)]
+   ["Other"
+    ("C-c C-s" "save" save-buffer)
+    ("C-c C-c" "save & status" exordium-smerge--save-and-status
+     :transient nil)
+    ("C-c C-k" "revert & status" exordium-smerge--revert-and-status
+     :transient nil)
+    (exordium-smerge:undo)
+    ("E" "ediff" smerge-ediff
+     :transient nil)]])
+
+(use-package smerge-mode
+  :ensure nil
+  :bind
+  (:map smerge-mode-map
+        ("C-c ^ d" . exordium-smerge-dispatch)))
+
+(defun exordium-smerge-dispatch-maybe ()
+  "Display `exordium-smerge-dispatch' when buffer is in `smerge-mode'."
+  (when (and smerge-mode exordium-smerge-show-dispatch)
+    (exordium-smerge-dispatch)))
+
+(use-package magit
+  :hook
+  (magit-diff-visit-file . exordium-smerge-dispatch-maybe))
 
 
 ;;; Git gutter fringe: display added/removed/changed lines in the left fringe.

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -98,13 +98,13 @@
 
 
 ;; SMerge Dispatch
-(defun exordium-smerge--save-and-status ()
+(defun exordium-smerge-save-and-status ()
   "Save current buffer and show Magit status buffer."
   (interactive)
   (save-buffer)
   (magit-status-setup-buffer))
 
-(defun exordium-smerge--revert-and-status ()
+(defun exordium-smerge-revert-and-status ()
   "Revert current buffer and run Magit status buffer."
   (interactive)
   (revert-buffer nil t)
@@ -145,9 +145,9 @@
     ("k" "kill current" smerge-kill-current)]
    ["Other"
     ("C-c C-s" "save" save-buffer)
-    ("C-c C-c" "save & status" exordium-smerge--save-and-status
+    ("C-c C-c" "save & status" exordium-smerge-save-and-status
      :transient nil)
-    ("C-c C-k" "revert & status" exordium-smerge--revert-and-status
+    ("C-c C-k" "revert & status" exordium-smerge-revert-and-status
      :transient nil)
     (exordium-smerge:undo)
     ("E" "ediff" smerge-ediff

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -122,6 +122,13 @@ The original window configuration will be restored when you quit out of magit."
   :group 'exordium
   :type  'boolean)
 
+(defcustom exordium-smerge-show-dispatch t
+  "It t, automatically show `exordium-smerge-dispatch' for unmerged files.
+This is when hitting RET on a file with a merge conflict in a
+Magit status buffer."
+  :group 'exordium
+  :type 'boolean)
+
 (defcustom exordium-help-extensions t
   "If t, use help extensions like `which-key' and `helpful-mode'."
   :group 'exordium


### PR DESCRIPTION
### Motivation

When I resolve merge conflicts I'd like to use keybindings to pick correct hunks. One option is using `ediff`, another is to rely on a more lightweight SMerge. The latter is loaded by default when hitting `RET` on a file that is marked as  `unmerged` in a Magit status buffer. However, I don't do merge often enough, that merge related keybindings had a chance to engrave in my memory. I'd like to see available keybindings in front of my eyes.

### Solution

Add a `transient` that is showing bindings for commands from `semrge-mode`. I took an idea from some forum post a few years back (can't find a reference though). Have also seen similar solution being implemented in [DOOM](https://github.com/hlissner/doom-emacs/blob/0769b47/modules/emacs/vc/autoload/hydra.el) yet it uses `hydra-mode` and VI-style keybindings. I thought, I'd rather use `transient` to keep things consistent with Magit.

### Comments
- I've picked `C-c C-s` for save buffer, as I think that is usefull to have extra checkpoints when doing merge. This is not the regular `C-x C-s`, as it seems to conflict with built-in `transient` commands.

- The `revert & status` reverts the unmerged file to the last saved checkpoint. I have been pondering about implementing reverting to the point that was when merge has started. But that seems to be more involved and I think for now an advise to abort the merge and start over should be enough. If there's a strong ask for that, I think I can try to do something in a following PR. Yet, there are some questions I don't seem to have a good answer at this point, so if you'd like to see such an extensions, please let me know your thoughts about::
  - How to capture such a state? I.e., when the file is not visited from `magit-status`
  - Where to keep it?
    - Memory? What if the diff is large?
    - File? How to manage the state, i.e., cleaning orphans etc.

- I've made the dispatch to be displayed by default, since I found it extremely useful to do a quick merge. For more complicated things one can just hit `E` and that will start a full blown `ediff` session.