### PR TITLE
Allow to start ag/rg directly from helm-projectile

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ expressions.
 * <kbd>C-S-r</kbd>: ripgrep search for text in current projectile project.
 * <kbd>M-x helm-multiple-swoop-all</kbd>: Swoop search within all buffers.
 
+Note that <kbd>C-S-a</kbd> and <kbd>C-S-r</kbd> work also directly from
+`helm-projectile-switch-project`. This means that you searching a project with `ag` or `rg`
+simply by selecting it in helm and hitting appropriate keybinding.
+
 ## Treemacs
 
 [Treemacs](https://github.com/Alexander-Miller/treemacs) is a tree layout file

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -52,6 +52,11 @@
     (kill-buffer)
     (jump-to-register :magit-fullscreen))
 
+  (defun exordium-magit--dont-insert-symbol-for-search ()
+    "Don't insert a symbol at point when starting ag or rg."
+    (setq-local helm-ag-insert-at-point nil)
+    (setq-local helm-rg-thing-at-point nil))
+
   ;;; Turn off the horrible warning about magit auto-revert of saved buffers
   (setq magit-last-seen-setup-instructions "1.4.0")
 
@@ -64,6 +69,9 @@
         ("c" . (function magit-clone))
    :map magit-status-mode-map
         ("q" . 'magit-quit-session))
+
+  :hook
+  (magit-status-mode . exordium-magit--dont-insert-symbol-for-search)
 
   :config
 ;;; Make `magit-status',`exordium-magit-log' (a wrapper around `magit-log' and


### PR DESCRIPTION
I found myself to search in a different project than the currently selected. That means that I usually did:
- `C-S-h`
- find the project
- either hit `RET` on it and select a file in the project, then hit `C-S-a` and start searching
- or hit `M-g`, hit `C-S-a`, hit `M-backspace`, start searching

This change lets to trigger a search (with an `ag` or a `rg`) directly from a `helm-projectile-switch-to-project`. It's enough to set the point on a project you wish to search, and hit `C-S-a` or `C-S-r` and start typing your query. So now I can
- `C-S-h`
- find the project
- hit `C-S-a` and start searching

I've also addressed the insertion of a symbol at point when initiating an `ag` search or a `rg` search from `magit-status` buffers. I found that I seldom have a need to use anything from a `magit-status` buffer and was annoyed that I always had to start by removing `Recent` before I could start a search.