### PR TITLE
Only use shell in org-babel

### DIFF
--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -39,9 +39,7 @@
      'org-babel-load-languages
      `((perl       . t)
        (ruby       . t)
-       ,(if (version< org-version "9.0")
-            '(sh         . t)
-          '(shell      . t))
+       (shell      . t)
        (python     . t)
        (emacs-lisp . t)
        (C          . t)


### PR DESCRIPTION
The `sh` was pre org-9.0. However, the lowest supported version of emacs (26.1) is shipped with org-9.1.9, so the check is redundant. To add to that org-9.4.4 in `gnu` package does not define a string version, causing the check to yield a failure.