### PR TITLE
Disable compilation on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,8 @@ jobs:
           path: '.emacs.d'
       - name: First start # So most modules are pulled in from melpa and gnu
         run: '.emacs.d/.ci/first-start.sh .emacs.d'
-      - name: Compilation # This pulls extra modules not enabled by default
-        run: '.emacs.d/.ci/compilation.sh .emacs.d'
+      # - name: Compilation # This pulls extra modules not enabled by default
+      #   run: '.emacs.d/.ci/compilation.sh .emacs.d'
       - name: Unit tests
         run: '.emacs.d/.ci/unit-tests.sh .emacs.d'
 


### PR DESCRIPTION
This has started giving `invalid-syntax-error`'s. This happened on `ubuntu-latest` for 27.1, 26.3 and a few other versions (other pipelines were aborted). See [here](https://github.com/pkryger/exordium/runs/1717059084). I've tried to disable `cider` but that just have shifted error elsewhere, see [here](https://github.com/pkryger/exordium/actions/runs/491777870).

While I would like to see we do compile on CI as it pulls more packages than the regular start and we could catch more errors early (i.e., like the [one]() in  `cmake-mode`), but I haven't figured out yet how to debug that to a point where I would be able to propose a fix. Any pointers welcome.

-----
A stack from the [original](https://github.com/pkryger/exordium/runs/1717059084) failure for a reference (`ubuntu-latest, 27.1`)
```
Debugger entered--Lisp error: (invalid-read-syntax "#")
53
  signal(invalid-read-syntax ("#"))
54
  package--with-response-buffer-1("https://elpa.gnu.org/packages/" #f(compiled-function () #<bytecode 0x1710439>) :file "seq-2.22.tar" :async nil :error-function #f(compiled-function () #<bytecode 0x6cbcbd>) :noerror nil)
55
  package-install-from-archive(#s(package-desc :name seq :version (2 22) :summary "Sequence manipulation functions" :reqs nil :kind tar :archive "gnu" :dir nil :extras ((:maintainer nil . "emacs-devel@gnu.org") (:authors ("Nicolas Petton" . "nicolas@petton.fr")) (:keywords "sequences") (:url . "http://elpa.gnu.org/packages/seq.html")) :signed nil))
56
  mapc(package-install-from-archive (#s(package-desc :name sesman :version (20190909 1754) :summary "Generic Session Manager" :reqs ((emacs (25))) :kind tar :archive "melpa-pinned" :dir nil :extras ((:commit . "edee869c209c016e5f0c5cbb8abb9f3ccd2d1e05") (:authors ("Vitalie Spinu")) (:maintainer "Vitalie Spinu") (:keywords "process") (:url . "https://github.com/vspinu/sesman")) :signed nil) #s(package-desc :name seq :version (2 22) :summary "Sequence manipulation functions" :reqs nil :kind tar :archive "gnu" :dir nil :extras ((:maintainer nil . "emacs-devel@gnu.org") (:authors ("Nicolas Petton" . "nicolas@petton.fr")) (:keywords "sequences") (:url . "http://elpa.gnu.org/packages/seq.html")) :signed nil) #s(package-desc :name spinner :version (1 7 3) :summary "Add spinners and progress-bars to the mode-line fo..." :reqs nil :kind single :archive "gnu" :dir nil :extras ((:keywords "processes" "mode-line") (:authors ("Artur Malabarba" . "emacs@endlessparentheses.com")) (:maintainer "Artur Malabarba" . "emacs@endlessparentheses.com") (:url . "https://github.com/Malabarba/spinner.el")) :signed nil) #s(package-desc :name queue :version (0 2) :summary "Queue data structure" :reqs nil :kind single :archive "gnu" :dir nil :extras ((:keywords "extensions" "data structures" "queue") (:authors ("Inge Wallin" . "inge@lysator.liu.se") ("Toby Cubitt" . "toby-predictive@dr-qubit.org")) (:maintainer "Toby Cubitt" . "toby-predictive@dr-qubit.org") (:url . "http://www.dr-qubit.org/emacs.php")) :signed nil) #s(package-desc :name a :version (20201203 1927) :summary "Associative data structure functions" :reqs ((emacs (25))) :kind single :archive "melpa-pinned" :dir nil :extras ((:commit . "3d341eb7813ee02b00ab28e11c915295bfd4b5a7") (:authors ("Arne Brasseur" . "arne@arnebrasseur.net")) (:maintainer "Arne Brasseur" . "arne@arnebrasseur.net") (:keywords "lisp") (:url . "https://github.com/plexus/a.el")) :signed nil) #s(package-desc :name parseclj :version (20201012 712) :summary "Clojure/EDN parser" :reqs ((emacs (25)) (a (0 1 0 -3 4))) :kind tar :archive "melpa-pinned" :dir nil :extras ((:commit . "eff941126859bc9e949eae5cd6c2592e731629f2") (:authors ("Arne Brasseur" . "arne@arnebrasseur.net")) (:maintainer "Arne Brasseur" . "arne@arnebrasseur.net") (:keywords "lisp" "clojure" "edn" "parser")) :signed nil) #s(package-desc :name parseedn :version (20200419 1124) :summary "Clojure/EDN parser" :reqs ((emacs (25)) (a (0 1 0 -3 4)) (parseclj (0 1 0))) :kind single :archive "melpa-pinned" :dir nil :extras ((:commit . "90cfe3df51b96f85e346f336c0a0ee6bf7fee508") (:authors ("Arne Brasseur" . "arne@arnebrasseur.net")) (:maintainer "Arne Brasseur" . "arne@arnebrasseur.net") (:keywords "lisp" "clojure" "edn" "parser")) :signed nil) #s(package-desc :name cider :version (20210104 915) :summary "Clojure Interactive Development Environment that R..." :reqs ((emacs (25)) (clojure-mode (5 12)) (parseedn (0 2)) (pkg-info (0 4)) (queue (0 2)) (spinner (1 7)) (seq (2 22)) (sesman (0 3 2))) :kind tar :archive "melpa-pinned" :dir nil :extras ((:commit . "3fac28541e03812990c771bd774bf8ea65c228c9") (:authors ("Tim King" . "kingtim@gmail.com") ("Phil Hagelberg" . "technomancy@gmail.com") ("Bozhidar Batsov" . "bozhidar@batsov.com") ("Artur Malabarba" . "bruce.connor.am@gmail.com") ("Hugo Duncan" . "hugo@hugoduncan.org") ("Steve Purcell" . "steve@sanityinc.com")) (:maintainer "Bozhidar Batsov" . "bozhidar@batsov.com") (:keywords "languages" "clojure" "cider") (:url . "http://www.github.com/clojure-emacs/cider")) :signed nil)))
57
  package-download-transaction((#s(package-desc :name sesman :version (20190909 1754) :summary "Generic Session Manager" :reqs ((emacs (25))) :kind tar :archive "melpa-pinned" :dir nil :extras ((:commit . "edee869c209c016e5f0c5cbb8abb9f3ccd2d1e05") (:authors ("Vitalie Spinu")) (:maintainer "Vitalie Spinu") (:keywords "process") (:url . "https://github.com/vspinu/sesman")) :signed nil) #s(package-desc :name seq :version (2 22) :summary "Sequence manipulation functions" :reqs nil :kind tar :archive "gnu" :dir nil :extras ((:maintainer nil . "emacs-devel@gnu.org") (:authors ("Nicolas Petton" . "nicolas@petton.fr")) (:keywords "sequences") (:url . "http://elpa.gnu.org/packages/seq.html")) :signed nil) #s(package-desc :name spinner :version (1 7 3) :summary "Add spinners and progress-bars to the mode-line fo..." :reqs nil :kind single :archive "gnu" :dir nil :extras ((:keywords "processes" "mode-line") (:authors ("Artur Malabarba" . "emacs@endlessparentheses.com")) (:maintainer "Artur Malabarba" . "emacs@endlessparentheses.com") (:url . "https://github.com/Malabarba/spinner.el")) :signed nil) #s(package-desc :name queue :version (0 2) :summary "Queue data structure" :reqs nil :kind single :archive "gnu" :dir nil :extras ((:keywords "extensions" "data structures" "queue") (:authors ("Inge Wallin" . "inge@lysator.liu.se") ("Toby Cubitt" . "toby-predictive@dr-qubit.org")) (:maintainer "Toby Cubitt" . "toby-predictive@dr-qubit.org") (:url . "http://www.dr-qubit.org/emacs.php")) :signed nil) #s(package-desc :name a :version (20201203 1927) :summary "Associative data structure functions" :reqs ((emacs (25))) :kind single :archive "melpa-pinned" :dir nil :extras ((:commit . "3d341eb7813ee02b00ab28e11c915295bfd4b5a7") (:authors ("Arne Brasseur" . "arne@arnebrasseur.net")) (:maintainer "Arne Brasseur" . "arne@arnebrasseur.net") (:keywords "lisp") (:url . "https://github.com/plexus/a.el")) :signed nil) #s(package-desc :name parseclj :version (20201012 712) :summary "Clojure/EDN parser" :reqs ((emacs (25)) (a (0 1 0 -3 4))) :kind tar :archive "melpa-pinned" :dir nil :extras ((:commit . "eff941126859bc9e949eae5cd6c2592e731629f2") (:authors ("Arne Brasseur" . "arne@arnebrasseur.net")) (:maintainer "Arne Brasseur" . "arne@arnebrasseur.net") (:keywords "lisp" "clojure" "edn" "parser")) :signed nil) #s(package-desc :name parseedn :version (20200419 1124) :summary "Clojure/EDN parser" :reqs ((emacs (25)) (a (0 1 0 -3 4)) (parseclj (0 1 0))) :kind single :archive "melpa-pinned" :dir nil :extras ((:commit . "90cfe3df51b96f85e346f336c0a0ee6bf7fee508") (:authors ("Arne Brasseur" . "arne@arnebrasseur.net")) (:maintainer "Arne Brasseur" . "arne@arnebrasseur.net") (:keywords "lisp" "clojure" "edn" "parser")) :signed nil) #s(package-desc :name cider :version (20210104 915) :summary "Clojure Interactive Development Environment that R..." :reqs ((emacs (25)) (clojure-mode (5 12)) (parseedn (0 2)) (pkg-info (0 4)) (queue (0 2)) (spinner (1 7)) (seq (2 22)) (sesman (0 3 2))) :kind tar :archive "melpa-pinned" :dir nil :extras ((:commit . "3fac28541e03812990c771bd774bf8ea65c228c9") (:authors ("Tim King" . "kingtim@gmail.com") ("Phil Hagelberg" . "technomancy@gmail.com") ("Bozhidar Batsov" . "bozhidar@batsov.com") ("Artur Malabarba" . "bruce.connor.am@gmail.com") ("Hugo Duncan" . "hugo@hugoduncan.org") ("Steve Purcell" . "steve@sanityinc.com")) (:maintainer "Bozhidar Batsov" . "bozhidar@batsov.com") (:keywords "languages" "clojure" "cider") (:url . "http://www.github.com/clojure-emacs/cider")) :signed nil)))
58
  package-install(cider)
59
  use-package-ensure-elpa(cider (t) nil)
60
  use-package-handler/:ensure(cider :ensure (t) (:preface ((eval-when-compile (with-demoted-errors "Cannot load cider: %S" nil (unless (featurep 'cider) (load "cider" nil t))))) :catch t :init nil :load (cider) :config (t)) nil)
61
  use-package-process-keywords(cider (:ensure (t) :preface ((eval-when-compile (with-demoted-errors "Cannot load cider: %S" nil (unless (featurep 'cider) (load "cider" nil t))))) :catch t :init nil :load (cider) :config (t)) nil)
62
  #f(compiled-function (name &rest args) "Declare an Emacs package by specifying a group of configuration options.\n\nFor full documentation, please see the README file that came with\nthis file.  Usage:\n\n  (use-package package-name\n     [:keyword [option]]...)\n\n:init            Code to run before PACKAGE-NAME has been loaded.\n:config          Code to run after PACKAGE-NAME has been loaded.  Note that\n                 if loading is deferred for any reason, this code does not\n                 execute until the lazy load has occurred.\n:preface         Code to be run before everything except `:disabled'; this\n                 can be used to define functions for use in `:if', or that\n                 should be seen by the byte-compiler.\n\n:mode            Form to be added to `auto-mode-alist'.\n:magic           Form to be added to `magic-mode-alist'.\n:magic-fallback  Form to be added to `magic-fallback-mode-alist'.\n:interpreter     Form to be added to `interpreter-mode-alist'.\n\n:commands        Define autoloads for commands that will be defined by the\n                 package.  This is useful if the package is being lazily\n                 loaded, and you wish to conditionally call functions in your\n                 `:init' block that are defined in the package.\n:hook            Specify hook(s) to attach this package to.\n\n:bind            Bind keys, and define autoloads for the bound commands.\n:bind*           Bind keys, and define autoloads for the bound commands,\n                 *overriding all minor mode bindings*.\n:bind-keymap     Bind a key prefix to an auto-loaded keymap defined in the\n                 package.  This is like `:bind', but for keymaps.\n:bind-keymap*    Like `:bind-keymap', but overrides all minor mode bindings\n\n:defer           Defer loading of a package -- this is implied when using\n                 `:commands', `:bind', `:bind*', `:mode', `:magic', `:hook',\n                 `:magic-fallback', or `:interpreter'.  This can be an integer,\n                 to force loading after N seconds of idle time, if the package\n                 has not already been loaded.\n:after           Delay the use-package declaration until after the named modules\n                 have loaded. Once load, it will be as though the use-package\n                 declaration (without `:after') had been seen at that moment.\n:demand          Prevent the automatic deferred loading introduced by constructs\n                 such as `:bind' (see `:defer' for the complete list).\n\n:if EXPR         Initialize and load only if EXPR evaluates to a non-nil value.\n:disabled        The package is ignored completely if this keyword is present.\n:defines         Declare certain variables to silence the byte-compiler.\n:functions       Declare certain functions to silence the byte-compiler.\n:load-path       Add to the `load-path' before attempting to load the package.\n:diminish        Support for diminish.el (if installed).\n:delight         Support for delight.el (if installed).\n:custom          Call `custom-set' or `set-default' with each variable\n                 definition without modifying the Emacs `custom-file'.\n                 (compare with `custom-set-variables').\n:custom-face     Call `customize-set-faces' with each face definition.\n:ensure          Loads the package using package.el if necessary.\n:pin             Pin the package to an archive." #<bytecode 0xb84ae5>)(cider)
63
  macroexpand((use-package cider) ((declare-function . byte-compile-macroexpand-declare-function) (eval-when-compile . #f(compiled-function (&rest body) #<bytecode 0x645c31>)) (eval-and-compile . #f(compiled-function (&rest body) #<bytecode 0x645c5d>)) (with-suppressed-warnings . #f(compiled-function (warnings &rest body) #<bytecode 0x645c79>))))
64
  macroexp-macroexpand((use-package cider) ((declare-function . byte-compile-macroexpand-declare-function) (eval-when-compile . #f(compiled-function (&rest body) #<bytecode 0x645c31>)) (eval-and-compile . #f(compiled-function (&rest body) #<bytecode 0x645c5d>)) (with-suppressed-warnings . #f(compiled-function (warnings &rest body) #<bytecode 0x645c79>))))
65
  byte-compile-recurse-toplevel((use-package cider) #f(compiled-function (form) #<bytecode 0x64d3f1>))
66
  byte-compile-toplevel-file-form((use-package cider))
67
  #f(compiled-function (inbuffer) #<bytecode 0x64bbdd>)(#<buffer  *Compiler Input*>)
68
  byte-compile-from-buffer(#<buffer  *Compiler Input*>)
69
  byte-compile-file("/home/runner/work/exordium/exordium/.emacs.d/modul...")
70
  batch-byte-compile-file("/home/runner/work/exordium/exordium/.emacs.d/modul...")
71
  batch-byte-compile()
72
  command-line-1(("--eval" "\n(progn\n   (setq debug-on-error t\n         user-em..." "-f" "batch-byte-compile"
```