### PR TITLE
Add exordium-flip-string-quotes

### DIFF
--- a/.ci/unit-tests.sh
+++ b/.ci/unit-tests.sh
@@ -14,4 +14,5 @@ ${EMACS} -Q --batch \
   (load-file "'${EMACS_DIR}'/init.el")
   (load-file "'${EMACS_DIR}'/modules/init-bde-style.t.el")
   (load-file "'${EMACS_DIR}'/modules/init-forge.t.el")
+  (load-file "'${EMACS_DIR}'/modules/init-util.t.el")
   (ert-run-tests-batch-and-exit))'

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -575,7 +575,9 @@ Otherwise escape quotes in the inner string (rationalising escaping)."
                                (forward-sexp)
                                (point))))
                  ;; assume generic string delimiter has a length of 3
-                 (quote-length (if (region-active-p)
+                 ;; emacs-26 is not returning a quote value in `syntax-ppss'
+                 (quote-length (if (or (version< emacs-version "27")
+                                       (region-active-p))
                                    (if (and (< 5 (- orig-end orig-start))
                                             (eq orig-quote
                                                 (char-after (+ 1 orig-start)))

--- a/modules/init-util.t.el
+++ b/modules/init-util.t.el
@@ -1,0 +1,219 @@
+;;; Unit tests for init-util.el.
+;;; To run all tests:
+;;;     M-x eval-buffer
+;;;     M-x ert
+
+(require 'init-util)
+(require 'ert)
+(require 'cl-lib)
+(require 'cl-macs)
+
+
+;; Utility functions
+
+;; The following is useful when need to transfer an expression from, say a
+;; `python-mode' to elisp. This has proven useful when creating test cases
+;; below, but I don't think it's a general purpose function.
+(defun exordium-yank-quoted-string ()
+  "Yank a string escaping it for emacs-lisp."
+  (interactive)
+  (insert (cl-prin1-to-string (substring-no-properties (current-kill 0)))))
+
+(cl-defstruct exordium-flip-string-test-case
+  "A test case describing a buffer for `exordium-flip-string-quotes' functions
+family. The following slots are defined:
+
+- INPUT: the text to be used in a temp buffer before test is run,
+
+- POINT-OR-REGION: the point (when number) or the region (when list) in a
+  temp buffer before test is run,
+
+- OUTPUT: a text in a temp buffer after the test has been run."
+  (input nil :read-only t)
+  (point-or-region nil :read-only t)
+  output)
+
+(defmacro with-exordium-flip-string-test-case (test-case &rest body)
+  "Execute BODY using a temporary buffer created according to TEST-CASE.
+Return the BODY return value"
+  (declare (ident defun))
+  `(let ((input (exordium-flip-string-test-case-input ,test-case))
+         (point-or-region (exordium-flip-string-test-case-point-or-region ,test-case)))
+     (with-temp-buffer
+       ;; Use `python-mode' for it richness of supported string formats.
+       (when (numberp point-or-region)
+         (let (python-mode-hook)
+           (python-mode)))
+       (insert input)
+       (cond
+        ((numberp point-or-region)
+         (goto-char point-or-region))
+        ((and point-or-region
+              (listp point-or-region))
+         (set-mark (car point-or-region))
+         (goto-char (cadr point-or-region))
+         (activate-mark)))
+       (prog1
+           ,@body
+         (setf (exordium-flip-string-test-case-output ,test-case)
+               (substring-no-properties (buffer-string)))))))
+
+;; Tests for `exordium-flip-string--even-chars-between'
+
+(ert-deftest test-exordium-flip-string--even-chars-between-one-dash ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...-.")))
+    (should-not (with-exordium-flip-string-test-case test-case
+                 (exordium-flip-string--even-chars-between ?- 2 5)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-two-dashes ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...--.")))
+    (should (with-exordium-flip-string-test-case test-case
+             (exordium-flip-string--even-chars-between ?- 2 6)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-three-dashes ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...---.")))
+    (should-not (with-exordium-flip-string-test-case test-case
+                 (exordium-flip-string--even-chars-between ?- 2 7)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-four-dashes ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...----.")))
+    (should (with-exordium-flip-string-test-case test-case
+             (exordium-flip-string--even-chars-between ?- 2 8)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-one-dash-begin ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...-.")))
+    (should-not (with-exordium-flip-string-test-case test-case
+                 (exordium-flip-string--even-chars-between ?- 4 5)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-two-dashes-begin ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...--.")))
+    (should (with-exordium-flip-string-test-case test-case
+             (exordium-flip-string--even-chars-between ?- 4 6)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-three-dashes-begin ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...---.")))
+    (should-not (with-exordium-flip-string-test-case test-case
+                 (exordium-flip-string--even-chars-between ?- 4 7)))))
+
+(ert-deftest test-exordium-flip-string--even-chars-between-four-dashes-begin ()
+  (let ((test-case (make-exordium-flip-string-test-case
+                    :input "...----.")))
+    (should (with-exordium-flip-string-test-case test-case
+             (exordium-flip-string--even-chars-between ?- 4 8)))))
+
+;; Tests for `exordium-flip-string-quotes'
+
+(defconst exordium-flip-string--data
+  '(("foo01 = \"a string\"" . "foo01 = 'a string'")
+    ("foo02 = 'a string'" . "foo02 = \"a string\"")
+    ("foo03 = \"\"\"a string\"\"\"" . "foo03 = '''a string'''")
+    ("foo04 = '''a string'''" . "foo04 = \"\"\"a string\"\"\"")
+    ("foo05 = \"a string 'with quote'\"" . "foo05 = 'a string \\'with quote\\''")
+    ("foo06 = 'a string \"with quote\"'" . "foo06 = \"a string \\\"with quote\\\"\"")
+    ("foo07 = \"a string \\\\'with quote\\\\'\"" . "foo07 = 'a string \\\\\\'with quote\\\\\\''")
+    ("foo08 = \"a string \\'with quote\\'\"" . "foo08 = 'a string \\'with quote\\''")
+    ("foo09 = 'a string \\\\\"with quote\\\\\"'" . "foo09 = \"a string \\\\\\\"with quote\\\\\\\"\"")
+    ("foo10 = 'a string \\\"with quote\\\"'" . "foo10 = \"a string \\\"with quote\\\"\"")
+    ("foo11 = \"\"\"a string 'with quote'\"\"\"" . "foo11 = '''a string 'with quote\\''''")
+    ("foo12 = '''a string \"with quote\"'''" . "foo12 = \"\"\"a string \"with quote\\\"\"\"\"")
+    ("foo13 = \"\"\"a string \"with quote\\\"\"\"\"" . "foo13 = '''a string \"with quote\"'''")
+    ("foo14 = '''a string 'with quote\\''''" . "foo14 = \"\"\"a string 'with quote'\"\"\"")
+    ("foo15 = \"\"\"a string \"\"with quote\"\\\"\"\"\"" . "foo15 = '''a string \"\"with quote\"\"'''")
+    ("foo16 = '''a string ''with quote'\\''''" . "foo16 = \"\"\"a string ''with quote''\"\"\"")
+    ("foo17 = \"\"\"a string 'with quote\\\\'\"\"\"" . "foo17 = '''a string 'with quote\\\\\\''''")
+    ("foo18 = '''a string \"with quote\\\\\"'''" . "foo18 = \"\"\"a string \"with quote\\\\\\\"\"\"\"")
+    ("foo19 = \"\"\"a string \"with quote\\\\\\\"\"\"\"" . "foo19 = '''a string \"with quote\\\\\"'''")
+    ("foo20 = '''a string 'with quote\\\\\\''''" . "foo20 = \"\"\"a string 'with quote\\\\'\"\"\"")
+    ("foo21 = \"\"\"a string '''with quote'''\"\"\"" . "foo21 = '''a string \\'\\'\\'with quote\\'\\'\\''''")
+    ("foo22 = \"\"\"a string ''with quote''\"\"\"" . "foo22 = '''a string ''with quote'\\''''")
+    ("foo23 = '''a string \"\"\"with quote\"\"\"'''" . "foo23 = \"\"\"a string \\\"\\\"\\\"with quote\\\"\\\"\\\"\"\"\"")
+    ("foo24 = '''a string \"\"with quote\"\"'''" . "foo24 = \"\"\"a string \"\"with quote\"\\\"\"\"\"")
+    ("foo25 = \"\"\"a string \\\"\\\"\\\"with quote\\\"\\\"\\\"\"\"\"" . "foo25 = '''a string \"\"\"with quote\"\"\"'''")
+    ("foo26 = '''a string \\'\\'\\'with quote\\'\\'\\''''" . "foo26 = \"\"\"a string '''with quote'''\"\"\"")
+    ("foo27 = \"\"\"a string \"with quote\" and something\"\"\"" . "foo27 = '''a string \"with quote\" and something'''")
+    ("foo28 = \"\"\"a string \"\"with quote\"\" and something\"\"\"" . "foo28 = '''a string \"\"with quote\"\" and something'''")
+    ("foo29 = '''a string 'with quote' and something'''" . "foo29 = \"\"\"a string 'with quote' and something\"\"\"")
+    ("foo30 = '''a string ''with quote'' and something'''" . "foo30 = \"\"\"a string ''with quote'' and something\"\"\"")))
+
+(ert-deftest test-exordium-flip-string-quotes-point ()
+  (dolist (datum exordium-flip-string--data)
+    (let ((test-case (make-exordium-flip-string-test-case
+                      :input (car datum)
+                      :point-or-region 12))
+          (expected (cdr datum)))
+      (with-exordium-flip-string-test-case test-case  (exordium-flip-string-quotes))
+      (should (string= expected
+                       (exordium-flip-string-test-case-output test-case))))))
+
+(ert-deftest test-exordium-flip-string-quotes-region ()
+  (dolist (datum exordium-flip-string--data)
+    (let ((test-case (make-exordium-flip-string-test-case
+                      :input (car datum)
+                      :point-or-region `(9 ,(+ 9 (length (car datum))))))
+          (expected (cdr datum)))
+      (with-exordium-flip-string-test-case test-case  (exordium-flip-string-quotes))
+      (should (string= expected
+                       (exordium-flip-string-test-case-output test-case))))))
+
+(defconst exordium-flip-string--flip-inner-data
+  '(("foo01 = \"a string\"" . "foo01 = 'a string'")
+    ("foo02 = 'a string'" . "foo02 = \"a string\"")
+    ("foo03 = \"\"\"a string\"\"\"" . "foo03 = '''a string'''")
+    ("foo04 = '''a string'''" . "foo04 = \"\"\"a string\"\"\"")
+    ("foo05 = \"a string 'with quote'\"" . "foo05 = 'a string \"with quote\"'")
+    ("foo06 = 'a string \"with quote\"'" . "foo06 = \"a string 'with quote'\"")
+    ("foo07 = \"a string \\\\'with quote\\\\'\"" . "foo07 = 'a string \\\\\"with quote\\\\\"'")
+    ("foo08 = \"a string \\'with quote\\'\"" . "foo08 = 'a string \\\"with quote\\\"'")
+    ("foo09 = 'a string \\\\\"with quote\\\\\"'" . "foo09 = \"a string \\\\'with quote\\\\'\"")
+    ("foo10 = 'a string \\\"with quote\\\"'" . "foo10 = \"a string \\'with quote\\'\"")
+    ("foo11 = \"\"\"a string 'with quote'\"\"\"" . "foo11 = '''a string \"with quote\"'''")
+    ("foo12 = '''a string \"with quote\"'''" . "foo12 = \"\"\"a string 'with quote'\"\"\"")
+    ("foo13 = \"\"\"a string \"with quote\\\"\"\"\"" . "foo13 = '''a string 'with quote\\''''")
+    ("foo14 = '''a string 'with quote\\''''" . "foo14 = \"\"\"a string \"with quote\\\"\"\"\"")
+    ("foo15 = \"\"\"a string \"\"with quote\"\\\"\"\"\"" . "foo15 = '''a string ''with quote'\\''''")
+    ("foo16 = '''a string ''with quote'\\''''" . "foo16 = \"\"\"a string \"\"with quote\"\\\"\"\"\"")
+    ("foo17 = \"\"\"a string 'with quote\\\\'\"\"\"" . "foo17 = '''a string \"with quote\\\\\"'''")
+    ("foo18 = '''a string \"with quote\\\\\"'''" . "foo18 = \"\"\"a string 'with quote\\\\'\"\"\"")
+    ("foo19 = \"\"\"a string \"with quote\\\\\\\"\"\"\"" . "foo19 = '''a string 'with quote\\\\\\''''")
+    ("foo20 = '''a string 'with quote\\\\\\''''" . "foo20 = \"\"\"a string \"with quote\\\\\\\"\"\"\"")
+    ("foo21 = \"\"\"a string '''with quote'''\"\"\"" . "foo21 = '''a string \"\"\"with quote\"\"\"'''")
+    ("foo22 = \"\"\"a string ''with quote''\"\"\"" . "foo22 = '''a string \"\"with quote\"\"'''")
+    ("foo23 = '''a string \"\"\"with quote\"\"\"'''" . "foo23 = \"\"\"a string '''with quote'''\"\"\"")
+    ("foo24 = '''a string \"\"with quote\"\"'''" . "foo24 = \"\"\"a string ''with quote''\"\"\"")
+    ("foo25 = \"\"\"a string \\\"\\\"\\\"with quote\\\"\\\"\\\"\"\"\"" . "foo25 = '''a string \\'\\'\\'with quote\\'\\'\\''''")
+    ("foo26 = '''a string \\'\\'\\'with quote\\'\\'\\''''" . "foo26 = \"\"\"a string \\\"\\\"\\\"with quote\\\"\\\"\\\"\"\"\"")
+    ("foo27 = \"\"\"a string \"with quote\" and something\"\"\"" . "foo27 = '''a string 'with quote' and something'''")
+    ("foo28 = \"\"\"a string \"\"with quote\"\" and something\"\"\"" . "foo28 = '''a string ''with quote'' and something'''")
+    ("foo29 = '''a string 'with quote' and something'''" . "foo29 = \"\"\"a string \"with quote\" and something\"\"\"")
+    ("foo30 = '''a string ''with quote'' and something'''" . "foo30 = \"\"\"a string \"\"with quote\"\" and something\"\"\"")))
+
+(ert-deftest test-exordium-flip-string-quotes-point-flip-inner ()
+  (dolist (datum exordium-flip-string--flip-inner-data)
+    (let ((test-case (make-exordium-flip-string-test-case
+                      :input (car datum)
+                      :point-or-region 12))
+          (expected (cdr datum)))
+      (with-exordium-flip-string-test-case test-case  (exordium-flip-string-quotes t))
+      (should (string= expected
+                       (exordium-flip-string-test-case-output test-case))))))
+
+(ert-deftest test-exordium-flip-string-quotes-region-flip-inner ()
+  (dolist (datum exordium-flip-string--flip-inner-data)
+    (let ((test-case (make-exordium-flip-string-test-case
+                      :input (car datum)
+                      :point-or-region `(9 ,(+ 9 (length (car datum))))))
+          (expected (cdr datum)))
+      (with-exordium-flip-string-test-case test-case  (exordium-flip-string-quotes t))
+      (should (string= expected
+                       (exordium-flip-string-test-case-output test-case))))))
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:


### PR DESCRIPTION
I've found myself programming in a few different languages that have multiple string formats, i.e., `?\'` and `?\"` delimeted (single and triple). What's more different projects use different conventions and are sometimes pretty picky on how the string is quoted. In some places it makes a semantic difference as well - looking at you Groovy's `GString`. Long story short,  I've found myself flipping these quotes manually more often than I'd like to. And that's a bit tedious.

I've Googled a bit for a solution, but haven't found anything that would work to my satisfaction. Hence, I came up with a one that handles most of cases that I've encountered (and a few more that I came up while writing). That is the `exordium-flip-string-quotes` function.

The function is capable of flipping quotes in a string at point. For that the string has to be in a valid syntax for the current mode. Alternatively, it can flip quotes in an active region. The latter is useful when, say a `?\'` quoted string is copied from say a web page into a language that requires `?\"` quoted strings.

I've also added a mode where the inner quotes are not escaped, and are merely flipped to opposite ones. The mode is activated with a prefix argument.

I decided not to give it any special binding and rather call it from `M-x`: I do it quite often, but not often enough to designate a key binding for it.

### Test implementation notes

I've been using the following snippet in Python to interactively asses if the function is doing a good job. After that I created a few data driven tests to ensure the function doesn't regress when I tune its bits and pieces. The latter, combined with CI, has proven pretty good as it immediately found a little difference in `syntax-ppss` in Emacs 26.

``` python
foo01 = "a string"
foo02 = 'a string'
foo03 = """a string"""
foo04 = '''a string'''

foo05 = "a string 'with quote'"
foo06 = 'a string "with quote"'

foo07 = "a string \\'with quote\\'"
foo08 = "a string \'with quote\'"

foo09 = 'a string \\"with quote\\"'
foo10 = 'a string \"with quote\"'

foo11 = """a string 'with quote'"""
foo12 = '''a string "with quote"'''

foo13 = """a string "with quote\""""
foo14 = '''a string 'with quote\''''
foo15 = """a string ""with quote"\""""
foo16 = '''a string ''with quote'\''''

foo17 = """a string 'with quote\\'"""
foo18 = '''a string "with quote\\"'''
foo19 = """a string "with quote\\\""""
foo20 = '''a string 'with quote\\\''''

foo21 = """a string '''with quote'''"""
foo22 = """a string ''with quote''"""
foo23 = '''a string """with quote"""'''
foo24 = '''a string ""with quote""'''

foo25 = """a string \"\"\"with quote\"\"\""""
foo26 = '''a string \'\'\'with quote\'\'\''''

foo27 = """a string "with quote" and something"""
foo28 = """a string ""with quote"" and something"""
foo29 = '''a string 'with quote' and something'''
foo30 = """a string ""with quote"" and something"""
```

When writing  `ert` tests I've also used the `exordium-yank-quoted-string` to produce these mesmerising escape sequences. But since its highly specialised function I left it only in a test module. And since reading the escaped strings reminds looking at Mandelbrot too much (to my taste at least), I decided to leave the original inputs here.