### PR TITLE
Bind C-c C-d in helpful-mode

### DIFF
--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -56,6 +56,7 @@
    :map emacs-lisp-mode-map
         ("C-c C-d" . #'helpful-at-point)
    :map helpful-mode-map
+        ("C-c C-d" . #'helpful-at-point)
         ("C-c C-o" . #'exordium-browse-url-at-point)))
 
 (use-package helm


### PR DESCRIPTION
This lets to dig deeper, using helpful, when browsing code in `helpful-mode`.  I think I like it better in many situations than `xref-find-definitions`. This looks like an `elisp` buffer after all.