### PR TITLE
Don't use functions from an obsolete cl.el

### DIFF
--- a/.ci/compilation.sh
+++ b/.ci/compilation.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-EMACS_DIR="${GITHUB_WORKSPACE:-~}/${1:-.emacs.d}"
+EMACS_DIR="$(cd ${GITHUB_WORKSPACE:-~}/${1:-.emacs.d}; pwd -P)/"
 EMACS="${EMACS:=emacs}"
 
 # Byte compile all `.el` files in modules, themes, and extensions

--- a/.ci/unit-test-cl.sh
+++ b/.ci/unit-test-cl.sh
@@ -2,7 +2,6 @@
 
 set -x
 set -e
-
 EMACS_DIR="$(cd ${GITHUB_WORKSPACE:-~}/${1:-.emacs.d}; pwd -P)/"
 EMACS="${EMACS:=emacs}"
 
@@ -16,4 +15,6 @@ ${EMACS} -Q --batch \
      (defun define-fringe-bitmap (&rest args)
        "Workaround for missing function in pre-27 non GUI purcell/setup-emacs."
        (car args)))
-   (load-file "'${EMACS_DIR}'/init.el"))'
+   (load-file "'${EMACS_DIR}'/init.el")
+   (load-file "'${EMACS_DIR}'/modules/init-util-cl.t.el")
+   (ert-run-tests-batch-and-exit))'

--- a/.ci/unit-tests.sh
+++ b/.ci/unit-tests.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-EMACS_DIR="${GITHUB_WORKSPACE:-~}/${1:-.emacs.d}"
+EMACS_DIR="$(cd ${GITHUB_WORKSPACE:-~}/${1:-.emacs.d}; pwd -P)/"
 EMACS="${EMACS:=emacs}"
 
 # Run all tests form *.t.el

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,8 @@ jobs:
       #   run: '.emacs.d/.ci/compilation.sh .emacs.d'
       - name: Unit tests
         run: '.emacs.d/.ci/unit-tests.sh .emacs.d'
+      - name: Verify no obsolete cl- functions
+        run: '.emacs.d/.ci/unit-test-cl.sh .emacs.d'
 
   pkryger-taps:
     runs-on: ${{ matrix.os }}

--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -170,36 +170,36 @@ current cursor position, if the cursor is within a class definition:
                         // my comment at whatever column I want
                         // tab goes here
 3. nil otherwise."
-  (case (caar c-syntactic-context)
+  (cl-case (caar c-syntactic-context)
     ((inclass innamespace)
      (save-excursion
        (let ((class-offset         ; extra offset for inner structs
               (c-langelem-col (car c-syntactic-context) t))
              (comment-column nil)) ; column number of last //
-         (loop
+         (cl-loop
           (beginning-of-line)
           (cond ((= (point) (point-min))
-                 (return nil))
+                 (cl-return nil))
                 ((re-search-forward "^ *//" (point-at-eol) t)
                  ;; looking at a comment line
                  (setq comment-column (- (current-column) 2))
                  (forward-line -1))
                 ((bde-is-member-function-declaration)
                  ;; looking at end of method declaration
-                 (return '+))
+                 (cl-return '+))
                 ((re-search-forward "} *$" (point-at-eol) t)
                  ;; looking at end of inline method definition
-                 (return '+))
+                 (cl-return '+))
                 ((re-search-forward "; *//" (point-at-eol) t)
                  ;; looking at beginning of data member comment block
-                 (return (- (current-column) 2 class-offset c-basic-offset)))
+                 (cl-return (- (current-column) 2 class-offset c-basic-offset)))
                 ((and comment-column
                       (re-search-forward "[_A-Za-z0-9]+; *$"
                                          (point-at-eol) t))
                  ;; looking at end of (long?) data member declaration
-                 (return (- comment-column class-offset c-basic-offset)))
+                 (cl-return (- comment-column class-offset c-basic-offset)))
                 (t
-                 (return nil)))))))
+                 (cl-return nil)))))))
     (t nil)))
 
 (defun bde-statement-block-intro-offset (element)
@@ -298,7 +298,7 @@ switch(val) {
       (insert " <class name>")
       (backward-char 12)
       ;; Read and process input
-      (loop
+      (cl-loop
        (let ((c (read-event "Inserting header")))
          (cond ((integerp c)
                 (when erase-hint (kill-line))
@@ -325,7 +325,7 @@ switch(val) {
                ((eq c 'right)
                 (forward-char 1))
                (t
-                (return nil)))
+                (cl-return nil)))
          (setq erase-hint nil))))))
 
 (defun bde-guess-class-name ()
@@ -1041,33 +1041,33 @@ the beginning of the first line, or nil if not found. It is safer
 to use this function in conjunction with `bde-in-comment-p'. Note
 that this function only considers lines that only contain a
 comment."
-  (loop
+  (cl-loop
    (beginning-of-line)
    (cond ((= (point) (point-min))
-          (return nil))
+          (cl-return nil))
          ((re-search-forward "^ *//" (point-at-eol) t)
           ;; looking at a comment line
           (forward-line -1))
          (t
           (forward-line 1)
-          (return (point))))))
+          (cl-return (point))))))
 
 (defun bde-comment-end ()
   "Return the position of the end of a comment block, at the end
 of the last line, or nil if not found. It is safer to use this
 function in conjunction with `bde-in-comment-p'. Note that this
 function only considers lines that only contain a comment."
-  (loop
+  (cl-loop
    (beginning-of-line)
    (cond ((= (point) (point-min))
-          (return nil))
+          (cl-return nil))
          ((re-search-forward "^ *//" (point-at-eol) t)
           ;; looking at a comment line
           (forward-line 1))
          (t
           (forward-line -1)
           (end-of-line)
-          (return (point))))))
+          (cl-return (point))))))
 
 (defun bde-repunctuate ()
   "Put two spaces at the end of sentences in the selected region

--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -89,9 +89,9 @@
   (let ((ext (bde-file-name-extension (buffer-file-name))))
     (let ((base-name    (exordium-string-truncate (buffer-name) (length ext)))
           (base-path    (exordium-string-truncate (buffer-file-name) (length ext)))
-          (matching-ext (cdr (find-if (lambda (i)
-                                        (string= (car i) ext))
-                                      exordium-cpp-header-switches))))
+          (matching-ext (cdr (cl-find-if (lambda (i)
+                                           (string= (car i) ext))
+                                         exordium-cpp-header-switches))))
       (when (and arg matching-ext)
         (setq matching-ext (cdr matching-ext)))
       (cond (matching-ext

--- a/modules/init-flb-mode.el
+++ b/modules/init-flb-mode.el
@@ -71,11 +71,11 @@ buffers (e.g. `buffer-list'), returns a subset of this list that
 contains all common buffers, e.g. the buffers that should be
 shared among all frames."
   (let ((buffers (funcall orig-fun)))
-    (loop for b in buffers
-          when (let ((n (buffer-name b)))
-                 (and (string-prefix-p "*" n)
-                      (string-suffix-p "*" n)))
-          collect b)))
+    (cl-loop for b in buffers
+             when (let ((n (buffer-name b)))
+                    (and (string-prefix-p "*" n)
+                         (string-suffix-p "*" n)))
+             collect b)))
 
 (defun flb-buffer-list (orig-fun &rest args)
   "Advice around `buffer-list': returns the list of buffers. Note
@@ -110,23 +110,23 @@ that this advice disregards the `orig-fun'."
 (defun flb-frame-owns-buffer-p (frame buffer)
   "Predicate testing if FRAME owns BUFFER, e.g. if BUFFER is only
   open in FRAME"
-  (loop for (key value) on flb-frame-buffers by #'cddr
-        ;; skip FRAME
-        unless (eq key frame)
-        ;; return t if BUFFER is never a member of value
-        never (member buffer value)))
+  (cl-loop for (key value) on flb-frame-buffers by #'cddr
+           ;; skip FRAME
+           unless (eq key frame)
+           ;; return t if BUFFER is never a member of value
+           never (member buffer value)))
 
 (defun flb-remove-dead-frames ()
   "Removes any dead frames from variable `flb-frame-buffers'"
   (let ((newlist ()))
-    (loop for (key value) on flb-frame-buffers by #'cddr
-          do (if (frame-live-p key)
-                 ;; Keep the frame
-                 (setq newlist (plist-put newlist key value))
-               ;; else don't keep it and kill any buffers it owns
-               (dolist (b value)
-                 (when (flb-frame-owns-buffer-p key b)
-                   (kill-buffer b)))))
+    (cl-loop for (key value) on flb-frame-buffers by #'cddr
+             do (if (frame-live-p key)
+                    ;; Keep the frame
+                    (setq newlist (plist-put newlist key value))
+                  ;; else don't keep it and kill any buffers it owns
+                  (dolist (b value)
+                    (when (flb-frame-owns-buffer-p key b)
+                      (kill-buffer b)))))
     (setq flb-frame-buffers newlist)))
 
 (defun flb-update-frame-buffers (frame buffer)
@@ -135,7 +135,7 @@ that this advice disregards the `orig-fun'."
   buffers and removes any dead buffers."
   (let ((local-buffers (plist-get flb-frame-buffers frame)))
     (cl-pushnew buffer local-buffers)
-    (setq local-buffers (remove-if-not #'buffer-live-p local-buffers))
+    (setq local-buffers (cl-remove-if-not #'buffer-live-p local-buffers))
     (setq flb-frame-buffers (plist-put flb-frame-buffers frame local-buffers))))
 
 (defun flb-post-command-hook ()

--- a/modules/init-rtags-cdb.el
+++ b/modules/init-rtags-cdb.el
@@ -93,8 +93,8 @@ a list of five sublists:
         (exclude-src-list ())
         (macro-list       ()))
     (dolist (record (exordium-read-file-lines compile-includes-file))
-      (incf line-number)
-      (setq value (second (split-string record " ")))
+      (cl-incf line-number)
+      (setq value (cl-second (split-string record " ")))
       (cond ((or (eq "" record)
                  (string-prefix-p "#" record))
              ;; Comment or empty string; skip it
@@ -157,11 +157,11 @@ could not be loaded. The property list looks like this:
            ;; Parse the file and return 3 lists: src, include, exclude
            (let ((directives (rtags-load-compile-includes-file-content
                               compile-includes-file)))
-             (let ((src-dirs    (first directives))
-                   (incl-dirs   (second directives))
-                   (excl-regexs (third directives))
-                   (excl-src    (fourth directives))
-                   (macros      (fifth directives))
+             (let ((src-dirs    (cl-first directives))
+                   (incl-dirs   (cl-second directives))
+                   (excl-regexs (cl-third directives))
+                   (excl-src    (cl-fourth directives))
+                   (macros      (cl-fifth directives))
                    (result      ()))
                ;; Scan src to get all subdirs that do not match the excludes
                (let (dirs)
@@ -244,7 +244,7 @@ the specified directory."
                              default-directory)))
               (dolist (file files)
                 (unless (rtags-is-excluded-p file exclude-files)
-                  (incf num-files)
+                  (cl-incf num-files)
                   (insert "  { \"directory\": \"" dirname "\",")
                   (newline)
                   (insert "    \"command\":   \""

--- a/modules/init-rtags-cmake.el
+++ b/modules/init-rtags-cmake.el
@@ -24,6 +24,7 @@
 
 (require 'init-prefs)
 (use-package rtags)
+(use-package cl-lib :ensure nil)
 
 ;; Note: for now we actually don't need to keep the build-dir of any known
 ;; project but we should need it later to automatically index new files created
@@ -148,11 +149,11 @@ directory."
   "Read the specified file and return the value associated with
 the specified key, or nil if no such key."
   (let* ((records          (exordium-read-file-lines file))
-         (matching-records (remove-if-not #'(lambda (record)
+         (matching-records (cl-remove-if-not #'(lambda (record)
                                               (string-prefix-p key record))
                                           records)))
     (when matching-records
-      (second (split-string (car matching-records) " ")))))
+      (cl-second (split-string (car matching-records) " ")))))
 
 (defun exordium-rtags-cmake-get-expanded-build-dir ()
   "Return the value of the pref `exordium-rtags-cmake-build-dir'

--- a/modules/init-rtags.el
+++ b/modules/init-rtags.el
@@ -206,7 +206,7 @@ otherwise."
                 (puid  (cdr (assoc 'euid attrs))))
            (when (and (eq puid uuid)
                       (string= pname "rdm"))
-              (return t))))))))
+              (cl-return t))))))))
 
 (defun exordium-rtags-start-rdm-impl (&optional open-buffer)
   "Start rdm in a subprocess. Open the rdm log buffer if
@@ -279,7 +279,7 @@ An optional second argument BOUND bounds the search: the match
 found must not extend after that position. This function also
 sets `match-data' to the entire match."
   (let ((org-pos (point)))
-    (block while-loop
+    (cl-block while-loop
       ;; While there are more matches for REGEXP
       (while (re-search-forward regexp bound t)
         (if (re-search-backward "^" org-pos t)
@@ -288,8 +288,8 @@ sets `match-data' to the entire match."
               (if (re-search-forward "$" bound t)
                   (progn
                     (set-match-data (list begin-pos (point)))
-                    (return-from while-loop (point)))
-                (return-from while-loop))))))))
+                    (cl-return-from while-loop (point)))
+                (cl-return-from while-loop))))))))
 
 (defun rtags-rdm-match-record-error (bound)
   "Search forward from point to BOUND for error."

--- a/modules/init-util-cl.t.el
+++ b/modules/init-util-cl.t.el
@@ -1,0 +1,38 @@
+;;; Unit tests for init-util.el obsolete cl aliases.
+;;; To run all tests:
+;;;     M-x eval-buffer
+;;;     M-x ert
+
+(require 'init-util)
+(require 'ert)
+(require 'cl-lib)
+
+
+;; Test to ensure no new obsolete `cl' aliases are added.
+;; It utilises `exordium-refs-cl-aliases'
+;; to find all aliases.
+
+(defvar exordium--test-found-obsolete-aliases)
+
+(defun exordium--test-collect-aliases (orig-fun &rest args)
+  "Collect results into `exordium--test-found-obsoltete-aliases'.
+
+This is meant to be applied as an advice around `elisp-refs--show-results'."
+  (when-let ((files (mapcar (lambda (result)
+                              (string-trim-right
+                               (string-trim-left (buffer-name (cdr result))
+                                                 " \\*refs-")
+                               "\\*"))
+                            (cl-third args))))
+    (add-to-list 'exordium--test-found-obsolete-aliases
+                 (cons (cl-first args) files))))
+
+(ert-deftest test-exordium-no-obsolete-aliases ()
+  (setq exordium--test-found-obsolete-aliases nil)
+  (let ((exordium-refs-cl-aliases--advice #'exordium--test-collect-aliases))
+    (exordium-refs-cl-aliases))
+  (should (eq exordium--test-found-obsolete-aliases nil)))
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -50,6 +50,7 @@
 (require 'init-lib)
 (require 'init-prefs)
 
+(use-package cl-lib :ensure nil)
 
 ;;; Match parentheses
 ;;; Ctrl-% = go to match paren
@@ -543,7 +544,7 @@ continues until at most POS-START."
       (setq even (if (< pos-start (- pos-end offset 2))
                      (not (eq (char-before (- pos-end offset 2)) char))
                    t))
-      (incf offset 2))
+      (cl-incf offset 2))
     even))
 
 (defun exordium-flip-string-quotes (&optional flip-inner)
@@ -607,7 +608,7 @@ Otherwise escape quotes in the inner string (rationalising escaping)."
                             (exordium-flip-string--even-chars-between
                              ?\\ orig-start (point)))
                     (insert-char ?\\)
-                    (incf orig-end))
+                    (cl-incf orig-end))
                 (when (and (< (point) (- orig-end 2))
                            (eq (char-after (+ 1 (point))) new-quote)
                            (eq (char-after (+ 2 (point))) new-quote))
@@ -617,13 +618,13 @@ Otherwise escape quotes in the inner string (rationalising escaping)."
                   (insert-char ?\\)
                   (forward-char)
                   (insert-char ?\\)
-                  (incf orig-end 3))))
+                  (cl-incf orig-end 3))))
              ((and
                (eq (char-after) orig-quote)
                (eq (char-before) ?\\))
               (backward-char)
               (delete-char 1)
-              (decf orig-end)))
+              (cl-decf orig-end)))
             (forward-char)))
         ;; A special case: the if the last quote in a string with a generic
         ;; string delimiter `(eq quote-length 3)' is the same as the new-quote


### PR DESCRIPTION
More and more packages stop using `cl.el`. The latter has a nice loop that defines aliases to new `cl-lib.el` names (the ones that start with `cl-` prefix). This causes surprises, when `cl.el` is not included anymore by one of the underlaying packages.

I've started by fixing known candidates like `case`, but then thought about more systematic approach. So I've taken the loop from `cl.el` and applied it to `elisp-refs` find functions and manually fixed all occurrences (my lisp-fu ain't good enough to do that automatically yet). But later I thought that it's quite easy to degenerate the code by using some of the non `cl-` prefixed aliases, so I expanded that idea to have:
- an interactive function `exordium-refs-cl-aliases` for humans to find mistakes,
- an automatic test that is running the latter on a PR.

Nothing should sneak in 😎.

Edit: typo