### PR TITLE
Add markdown changes for Tomorrow theme

### DIFF
--- a/modules/init-elisp.el
+++ b/modules/init-elisp.el
@@ -23,6 +23,7 @@ bug (page break lines wrap around)."
   (emacs-lisp-mode . exordium-page-break-lines-hook))
 
 ;;; Animation when evaluating a defun or a region:
+(require 'facemenu)  ;; no longer preloaded in emacs 28, but used by `highlight' without require
 (use-package highlight)
 (use-package eval-sexp-fu)
 

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -331,7 +331,8 @@ names to which it refers are bound."
                     ,(append `(:foreground ,green
                                :overline ,green
                                :background ,selection
-                               :box (:style released-button))
+                               :box (:style released-button)
+                               :extend t)
                              (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
      (org-level-2 ((t (:foreground ,aqua))))
      (org-level-3 ((t (:foreground ,purple))))
@@ -367,26 +368,27 @@ names to which it refers are bound."
      (org-warning ((t (:weight bold :foreground ,red))))
 
      ;; Markdown
-     (markdown-url-face ((t (:inherit link :foreground ,yellow :weight normal))))
-     (markdown-link-face ((t (:foreground ,orange :underline t :weight bold))))
+     (markdown-url-face ((t (:inherit link :foreground ,foreground :weight normal))))
+     (markdown-plain-url-face ((t (:inherit link :foreground ,foreground :weight normal))))
+     (markdown-link-face ((t (:inherit link :foreground ,red :weight normal))))
      (markdown-header-face-1 ((t
-                               ,(append `(:weight bold :foreground ,red)
+                               ,(append `(:weight bold :foreground ,green)
                                         (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4)) nil))))
      (markdown-header-face-2 ((t
-                               ,(append `(:weight bold :foreground ,red)
+                               ,(append `(:weight bold :foreground ,green)
                                         (if exordium-theme-use-big-font `(:height ,exordium-height-plus-2)) nil))))
-     (markdown-header-face-3 ((t (:foreground ,red :weight bold))))
-     (markdown-header-face-4 ((t (:foreground ,red :weight normal))))
-     (markdown-header-face-5 ((t (:foreground ,red :weight bold :slant italic))))
-     (markdown-header-delimiter-face ((t (:foreground ,red))))
-     (markdown-hr-face ((t (:foreground ,red))))
-     (markdown-bold-face ((t (:foreground ,green :weight bold))))
+     (markdown-header-face-3 ((t (:foreground ,green :weight bold))))
+     (markdown-header-face-4 ((t (:foreground ,green :weight normal))))
+     (markdown-header-face-5 ((t (:foreground ,green :weight bold :slant italic))))
+     (markdown-header-delimiter-face ((t (:foreground ,green))))
+     (markdown-hr-face ((t (:foreground ,green))))
+     (markdown-bold-face ((t (:foreground ,yellow :weight bold))))
      (markdown-italic-face ((t (:foreground ,foreground :weight normal :slant italic))))
-     (markdown-list-face ((t (:foreground ,red :weight normal))))
-     (markdown-inline-code-face ((t (:foreground ,aqua :weight normal))))
+     (markdown-list-face ((t (:foreground ,green :weight normal))))
+     (markdown-inline-code-face ((t (:foreground ,red :weight normal))))
      (markdown-markup-face ((t (:foreground ,blue))))
      (markdown-pre-face ((t (:foreground ,aqua))))
-     (markdown-gfm-checkbox-face ((t (:foreground ,red))))
+     (markdown-gfm-checkbox-face ((t (:foreground ,yellow))))
      (markdown-table-face ((t (:foreground ,comment))))
 
      ;; js2-mode


### PR DESCRIPTION
I changed the markdown faces to be more readable. This is inline with common other themes for [other editors](https://kortina.nyc/essays/suping-up-vs-code-as-a-markdown-notebook/). Looks like this:

<img width="893" alt="Screen Shot 2021-04-02 at 11 29 27 AM" src="https://user-images.githubusercontent.com/2925855/113429541-b4141000-93a6-11eb-9130-f4e40661426a.png">
