### PR TITLE
Remove magit-fullscreen- from register-alist after use

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -115,6 +115,18 @@
                                       exordium-projectile-add-known-project)
     (projectile-add-known-project directory)))
 
+(use-package desktop
+  :ensure nil
+  :when exordium-desktop
+  :init
+  (defun exordium--desktop-save-hook ()
+    (setq register-alist
+          (assoc-delete-all ":exordium-magit-fullscreen-"
+                            register-alist
+                            (lambda (key val)
+                              (string-prefix-p val (symbol-name key))))))
+  :hook
+  (desktop-save . exordium--desktop-save-hook))
 
 ;;; Don't show "MRev" in the modeline
 (when (bound-and-true-p magit-auto-revert-mode)

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -55,7 +55,9 @@
                       exordium--magit-fullscreen)))
       (kill-buffer)
       (when register
-        (jump-to-register register))))
+        (jump-to-register register)
+        (setq register-alist
+              (assoc-delete-all register register-alist)))))
 
   (defun exordium-magit--dont-insert-symbol-for-search ()
     "Don't insert a symbol at point when starting ag or rg."


### PR DESCRIPTION
This prevents the `register-alist` to overgrow. The `register-alist` is one of variables being saved by `desktop-save-mode`. I'd rather the Exordium feature not to interfere with the latter than to remove `register-alist` from `desktop-globals-to-save`.