### PR TITLE
Don't use register for exordium-magit-fullscreen

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -89,11 +89,11 @@
   (when exordium-use-magit-fullscreen
 
     (defun exordium--magit-fullscreen (orig-fun &rest args)
-      (let* ((exordium--magit-fullscreen-current-configuration
-              ;; Favour current configuration should it already exist in the stack
-              (or (and (boundp 'exordium--magit-fullscreen-current-configuration)
-                       exordium--magit-fullscreen-current-configuration)
-                  (list (current-window-configuration) (point-marker)))))
+      (let ((exordium--magit-fullscreen-current-configuration
+             ;; Favour current configuration should it already exist in the stack
+             (or (and (boundp 'exordium--magit-fullscreen-current-configuration)
+                      exordium--magit-fullscreen-current-configuration)
+                 (list (current-window-configuration) (point-marker)))))
         (apply orig-fun args)
         (delete-other-windows)
         (setq-local exordium--magit-fullscreen-configuration

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -110,19 +110,6 @@
                                       exordium-projectile-add-known-project)
     (projectile-add-known-project directory)))
 
-(use-package desktop
-  :ensure nil
-  :when exordium-desktop
-  :init
-  (defun exordium--desktop-save-hook ()
-    (setq register-alist
-          (assoc-delete-all ":exordium-magit-fullscreen-"
-                            register-alist
-                            (lambda (key val)
-                              (string-prefix-p val (symbol-name key))))))
-  :hook
-  (desktop-save . exordium--desktop-save-hook))
-
 ;;; Don't show "MRev" in the modeline
 (when (bound-and-true-p magit-auto-revert-mode)
   (diminish 'magit-auto-revert-mode))


### PR DESCRIPTION
I've run into a few issues when using most recent implementation of `exordium-magit-fullscreen`.

When debugging it turned out that magit calls a few advised functions from each other. That was resulting in an intermittent windows configuration to be stored in a register.

A short dive into `window-configuration-to-register` showed that storing window configuration is actually a very simple operation. That allowed to do a simple check for a variable existence in a stack (defined in a `let` form), to only capture the very first window configuration.

In addition I've decided to re-purpose the extra level of indirection - i.e., the buffer local variable used to strore register name. Now it holds desired windows configuration that is applied in `magit-quit-session`.

Changes above allow for a nice stack unwinding when one magit is started from another magit (i.e., when in buffer, call `projectile-change-project` but instead of hitting `RET` to go to file selection, hit `M-g` to go to magit for that project).

I hope this is last refactoring of this functionality 🤔