### PR TITLE
add org-headline-mode

### DIFF
--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -353,6 +353,7 @@ names to which it refers are bound."
                                     (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
      (org-todo ((t (:foreground ,red :weight bold :box nil))))
      (org-done ((t (:foreground ,green :weight bold :box nil))))
+     (org-headline-done ((t (:foreground ,comment :box nil))))
      (org-checkbox ((t (:background ,yellow :foreground ,background :weight bold))))
      (org-ellipsis ((t (:foreground ,comment))))
      (org-footnote ((t (:foreground ,aqua))))


### PR DESCRIPTION
Small change to the tomorrow theme for org mode, to make the "done" items (here `STOP` and `DONE`) be grayed out, so the stuff that is not done is more visible.

<img width="382" alt="Screen Shot 2021-08-13 at 6 02 19 PM" src="https://user-images.githubusercontent.com/2925855/129422433-23878879-a5e5-4a5f-9e3b-9ce3aa544251.png">
