### PR TITLE
Add visual changes to org-mode, markdown and git gutter fringe

### DIFF
--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -230,7 +230,17 @@ The function is meant to be used as an advice with conjunction with `exordium-ma
               ("d" . 'git-gutter:popup-hunk)
               ("r" . 'git-gutter:revert-hunk))
   :init
-  (add-hook 'git-gutter:update-hooks 'magit-revert-buffer-hook))
+  (add-hook 'git-gutter:update-hooks 'magit-revert-buffer-hook)
+  :config
+  ;; Style
+  (when (eq exordium-git-gutter-fringe-style :flat)
+    (setq-default fringes-outside-margins t)
+    (define-fringe-bitmap 'git-gutter-fr:added [224]
+      nil nil '(center repeated))
+    (define-fringe-bitmap 'git-gutter-fr:modified [224]
+      nil nil '(center repeated))
+    (define-fringe-bitmap 'git-gutter-fr:deleted [128 192 224 240]
+      nil nil 'bottom)))
 
 
 

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -20,6 +20,7 @@
   (setq org-todo-keywords
         '((sequence "TODO" "WORK" "WAIT" "DONE")))
   (setq org-src-fontify-natively t)
+  (setq org-fontify-whole-heading-line t)
   (setq org-src-preserve-indentation t)
   (setq org-completion-use-ido t)
   (when exordium-enable-org-export

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -354,6 +354,11 @@ default color."
   :type 'number
   :group 'exordium)
 
+(defcustom exordium-height-plus-10 2.0
+  "Font size +5."
+  :type 'number
+  :group 'exordium)
+
 
 
 ;;; Programming
@@ -405,6 +410,13 @@ Disables flyspell if set to nil."
 opened in TRAMP mode."
   :group 'exordium
   :type  'boolean)
+
+(defcustom exordium-git-gutter-fringe-style :flat
+  "Style for git gutter fringe markers.
+:default = unchanged.
+:flat = doom-style"
+  :group 'exordium
+  :type 'symbol)
 
 ;;; See init-cpp.el
 (defcustom exordium-enable-c++11-keywords :simple

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -355,7 +355,7 @@ default color."
   :group 'exordium)
 
 (defcustom exordium-height-plus-10 2.0
-  "Font size +5."
+  "Font size +10."
   :type 'number
   :group 'exordium)
 

--- a/themes/color-theme-atom-one.el
+++ b/themes/color-theme-atom-one.el
@@ -314,7 +314,8 @@ names to which it refers are bound."
      (grep-match-face ((t (:foreground nil :background nil :inherit match))))
 
      ;; Org
-     (org-level-1 ((t ,(append `(:foreground ,atom-one-dark-orange-1)
+     (org-level-1 ((t ,(append `(:foreground ,atom-one-dark-orange-1
+                                 :overline ,atom-one-dark-orange-1)
                                (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
      (org-level-2 ((t (:foreground ,atom-one-dark-mono-1))))
      (org-level-3 ((t (:foreground ,atom-one-dark-mono-2))))

--- a/themes/color-theme-monokai.el
+++ b/themes/color-theme-monokai.el
@@ -469,16 +469,16 @@ names to which it refers are bound."
       ((t (:foreground ,monokai-bg))))
      (org-level-1
       ((t (:inherit ,s-variable-pitch
-                :height ,monokai-height-plus-4 :foreground ,orange))))
+           :height ,monokai-height-plus-4 :foreground ,orange :overline ,orange))))
      (org-level-2
       ((t (:inherit ,s-variable-pitch
-                :height ,monokai-height-plus-3 :foreground ,green))))
+           :height ,monokai-height-plus-3 :foreground ,green))))
      (org-level-3
       ((t (:inherit ,s-variable-pitch
-                :height ,monokai-height-plus-2 :foreground ,blue))))
+           :height ,monokai-height-plus-2 :foreground ,blue))))
      (org-level-4
       ((t (:inherit ,s-variable-pitch
-                :height ,monokai-height-plus-1 :foreground ,yellow))))
+           :height ,monokai-height-plus-1 :foreground ,yellow))))
      (org-level-5
       ((t (:inherit ,s-variable-pitch :foreground ,cyan))))
      (org-level-6

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -207,7 +207,8 @@ names to which it refers are bound."
                            ,(append `(:weight bold :foreground ,cyan)
                                     (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
      (org-level-1 ((t
-                    ,(append `(:foreground ,base0)
+                    ,(append `(:foreground ,base0
+                               :overline ,base0)
                              (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
 
      ;; outline

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -330,13 +330,13 @@ names to which it refers are bound."
      (org-level-1 ((t
                     ,(append `(:foreground ,green
                                :overline ,green
-                               :background ,selection
-                               :box (:style released-button)
+                               ;;:background ,selection
+                               :inherit nil
                                :extend t)
                              (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
      (org-level-2 ((t (:foreground ,aqua))))
      (org-level-3 ((t (:foreground ,purple))))
-     (org-level-4 ((t (:foreground ,comment))))
+     (org-level-4 ((t (:foreground ,blue))))
      (org-agenda-structure ((t (:foreground ,purple))))
      (org-agenda-date ((t (:foreground ,blue :underline nil))))
      (org-agenda-done ((t (:foreground ,green))))
@@ -350,11 +350,11 @@ names to which it refers are bound."
      (org-document-info-keyword ((t (:foreground ,green))))
      (org-document-title ((t
                            ,(append `(:weight bold :foreground ,green)
-                                    (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
+                                    (if exordium-theme-use-big-font `(:height ,exordium-height-plus-10) nil)))))
      (org-todo ((t (:foreground ,red :weight bold :box nil))))
      (org-done ((t (:foreground ,green :weight bold :box nil))))
      (org-headline-done ((t (:foreground ,comment :box nil))))
-     (org-checkbox ((t (:background ,yellow :foreground ,background :weight bold))))
+     (org-checkbox ((t (:background ,selection :foreground ,yellow :weight bold))))
      (org-ellipsis ((t (:foreground ,comment))))
      (org-footnote ((t (:foreground ,aqua))))
      (org-formula ((t (:foreground ,red))))
@@ -364,7 +364,7 @@ names to which it refers are bound."
      (org-scheduled-previously ((t (:foreground ,orange))))
      (org-scheduled-today ((t (:foreground ,green))))
      (org-special-keyword ((t (:foreground ,orange))))
-     (org-table ((t (:foreground ,foreground))))
+     (org-table ((t (:foreground ,comment))))
      (org-upcoming-deadline ((t (:foreground ,orange))))
      (org-warning ((t (:weight bold :foreground ,red))))
 
@@ -372,15 +372,19 @@ names to which it refers are bound."
      (markdown-url-face ((t (:inherit link :foreground ,foreground :weight normal))))
      (markdown-plain-url-face ((t (:inherit link :foreground ,foreground :weight normal))))
      (markdown-link-face ((t (:inherit link :foreground ,red :weight normal))))
-     (markdown-header-face-1 ((t
-                               ,(append `(:weight bold :foreground ,green)
-                                        (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4)) nil))))
-     (markdown-header-face-2 ((t
-                               ,(append `(:weight bold :foreground ,green)
-                                        (if exordium-theme-use-big-font `(:height ,exordium-height-plus-2)) nil))))
-     (markdown-header-face-3 ((t (:foreground ,green :weight bold))))
-     (markdown-header-face-4 ((t (:foreground ,green :weight normal))))
-     (markdown-header-face-5 ((t (:foreground ,green :weight bold :slant italic))))
+     (markdown-header-face-1 ((t ,(append
+                                   `(:weight bold :foreground ,green)
+                                   (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4)) nil))))
+     (markdown-header-face-2 ((t ,(append
+                                   `(:weight bold :foreground ,green)
+                                   (if exordium-theme-use-big-font `(:height ,exordium-height-plus-2)) nil))))
+     (markdown-header-face-3 ((t (:foreground ,green :weight bold :slant italic))))
+     (markdown-header-face-4 ((t ,(append
+                                   `(:weight normal :foreground ,green :slant italic)
+                                   (if exordium-theme-use-big-font `(:height ,exordium-height-minus-1)) nil))))
+     (markdown-header-face-5 ((t ,(append
+                                   `(:weight normal :foreground ,green :slant italic)
+                                   (if exordium-theme-use-big-font `(:height ,exordium-height-minus-1)) nil))))
      (markdown-header-delimiter-face ((t (:foreground ,green))))
      (markdown-hr-face ((t (:foreground ,green))))
      (markdown-bold-face ((t (:foreground ,yellow :weight bold))))

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -330,7 +330,6 @@ names to which it refers are bound."
      (org-level-1 ((t
                     ,(append `(:foreground ,green
                                :overline ,green
-                               ;;:background ,selection
                                :inherit nil
                                :extend t)
                              (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))

--- a/themes/color-theme-zenburn.el
+++ b/themes/color-theme-zenburn.el
@@ -708,7 +708,9 @@ names to which it refers are bound."
      (org-document-title ((t (:inherit ,exordium-variable-pitch :weight bold :foreground ,zenburn-blue
                                        ,@(when exordium-theme-use-big-font
                                            (list :height exordium-height-plus-4))))))
-     (org-level-1 ((t (:inherit ,exordium-variable-pitch :foreground ,zenburn-orange
+     (org-level-1 ((t (:inherit ,exordium-variable-pitch
+                                :foreground ,zenburn-orange
+                                :overline ,zenburn-orange
                                 ,@(when exordium-theme-use-big-font
                                     (list :height exordium-height-plus-4))))))
      (org-level-2 ((t (:inherit ,exordium-variable-pitch :foreground ,zenburn-green+4


### PR DESCRIPTION
This adds a few visual changes to the Tomorrow theme for Org-Mode and Markdown: essentially the title and headers are more visible. It also adds support for various styles of git-gutter-fringe in preferences. The `:default` style does not change anything, while the `:flat` style shows flat git markers similarly to Doom-Emacs or modern editors like VS-Code. For example:

<img width="983" alt="Screen Shot 2022-01-16 at 1 18 07 PM" src="https://user-images.githubusercontent.com/2925855/149672790-fb45919e-3afe-49c3-9de6-dee520d9a1c6.png">

