### PR TITLE
Update CI for emacs 28

### DIFF
--- a/.ci/first-start.sh
+++ b/.ci/first-start.sh
@@ -6,9 +6,15 @@ set -e
 EMACS_DIR="$(cd ${GITHUB_WORKSPACE:-~}/${1:-.emacs.d}; pwd -P)/"
 EMACS="${EMACS:=emacs}"
 
+# Redefine ask-user-about-lock as the melpa seems to stumble on it
+# quite often in macos runs. Strategy: wait for 5s then grab the lock
+# anyway.
 ${EMACS} -Q --batch \
          --eval '
 (progn
    (setq debug-on-error t
          user-emacs-directory "'${EMACS_DIR}'")
+   (defun ask-user-about-lock (file opponent)
+     (sleep-for 5)
+     t)
    (load-file "'${EMACS_DIR}'/init.el"))'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
         emacs_version:
           - 27.1
           - 27.2
+          - 28.1
           - snapshot
     steps:
       - uses: purcell/setup-emacs@master
@@ -40,11 +41,13 @@ jobs:
 
   pkryger-taps:
     runs-on: ${{ matrix.os }}
+    env:
+      ci_tests: true
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
-            emacs_version: 27.2
+            emacs_version: 28.1
           - os: macos-latest
             emacs_version: snapshot
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ prefs.el
 local
 
 # Melpa packages
-elpa
+elpa*/
 
 # Caches
 eln-cache/


### PR DESCRIPTION
There are a few updates here, but I think they can go in a single PR:
- After upgrading to 28.1.90, Emacs decided to create a completely new `elpa-28.1.90` directory and reinstall all packages. I've extended `.gitignore` to account for that.
- Update to CI to include Emacs 28.1.
- Update CI so it will pass tests with my taps.
- Update CI to make macOS more likely to pass. Apparently there was a race condition when melpa packages are installed. It, however, cannot be resolved in a batch mode - the `ask-user-about-lock` signals error. Documentation for the latter suggest it's intended for the user to override it. I decided to take a strategy of waiting for 5s then grabbing the _lock_ anyway (and keeping fingers crossed that the other thread has already released the _lock_). N.B. from the way it works I gather the stylised _lock_ is not a lock like i.e., mutex. It's more likely a marker that some resource is being used, that can be overwritten by the opponent.
- Update the `exordium-flip-string-quotes`. The Emacs 28 has changed how `python-mode` parser sees universally delimeted strings (the ones with triple quotes). In Emacs up to 28 it was a single string, now it there are three: one made with first two opening quote characters, one starting from the third opening quote character up to the first closing quote character, and one made with the last two closing quote characters (try `(forward-sexp)` with point at the strategic places). I updated the function to account for that (and still working in Emacs 27).