### PR TITLE
Use `C-c D` for docker

### DIFF
--- a/modules/init-docker.el
+++ b/modules/init-docker.el
@@ -1,7 +1,8 @@
 ;;;; Configuration of Docker related features
 
 (use-package docker
-  :bind ("C-c d" . docker))
+  :bind ("C-c D" . docker))
+
 
 (use-package dockerfile-mode
   :mode


### PR DESCRIPTION
It's been introduced recently with #197, but it clashes with `duplicate-line-or-region`. Let's go back to original behaviour and use something similar, albeit slightly more difficult to type.