### PR TITLE
Fine tune org-mode

### DIFF
--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -50,7 +50,8 @@
        (python     . t)
        (emacs-lisp . t)
        (C          . t)
-       (dot        . t)))))
+       (dot        . t)
+       (sql        . t)))))
 
 
 ;;; Show org-mode bullets as UTF-8 characters.

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -30,14 +30,7 @@
   (org-src-preserve-indentation t)
   (org-confirm-babel-evaluate (not exordium-no-org-babel-confirm)
                               "Turn off the confirmation for code eval when using org-babel.")
-  (org-html-htmlize-output-type (if exordium-org-export-css
-                                    'css
-                                  org-html-htmlize-output-type)
-                                "Configure export using a css style sheet")
-  (org-html-head (if exordium-org-export-css
-                     exordium-org-export-css-stylesheet
-                   org-html-head)
-                 "Configure export using a css style sheet")
+  (org-support-shift-select t)
   :config
   (add-hook 'org-src-mode-hook
             #'(lambda ()
@@ -70,7 +63,16 @@
 
 (use-package ox-html
   :ensure org
-  :after (org))
+  :after (org)
+  :custom
+  (org-html-htmlize-output-type (if exordium-org-export-css
+                                    'css
+                                  org-html-htmlize-output-type)
+                                "Configure export using a css style sheet")
+  (org-html-head (if exordium-org-export-css
+                     exordium-org-export-css-stylesheet
+                   org-html-head)
+                 "Configure export using a css style sheet"))
 
 (use-package ox-md
   :ensure org

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -18,6 +18,7 @@
   (org-todo-keyword-faces
    '(("WORK" . exordium-org-work)
      ("WAIT" . exordium-org-wait)))
+  (org-startup-folded t)
   (org-log-into-drawer t)
   (org-startup-truncated nil)
   (org-startup-with-inline-images t)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -35,6 +35,11 @@
                    org-html-head)
                  "Configure export using a css style sheet")
   :config
+  (add-hook 'org-src-mode-hook
+            #'(lambda ()
+                (make-local-variable 'flychek-disabled-checkers)
+                (add-to-list 'flycheck-disabled-checkers 'emacs-lisp-checkdoc)))
+  (add-hook 'org-mode-hook #'turn-on-visual-line-mode)
   ;; TODO: delete `exordium-enable-org-export'??
   (when exordium-enable-org-export
     ;; Enable org-babel for perl, ruby, sh, python, emacs-lisp, C, C++, etc

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -8,10 +8,20 @@
   (add-hook 'org-mode-hook 'turn-on-visual-line-mode)
 
   :config
-  (setq org-startup-truncated nil)
-  (setq org-startup-with-inline-images t)
+  (defface exordium-org-wait '((t (:inherit org-todo)))
+    "Face for WAIT keywords."
+    :group 'exordium)
+  (defface exordium-org-work '((t (:inherit org-todo)))
+    "Face for WORK keywords."
+    :group 'exordium)
+  (setq org-todo-keyword-faces
+        '(("WORK" . exordium-org-work)
+          ("WAIT" . exordium-org-wait)))
   (setq org-todo-keywords
         '((sequence "TODO" "WORK" "WAIT" "DONE")))
+
+  (setq org-startup-truncated nil)
+  (setq org-startup-with-inline-images t)
   (setq org-src-fontify-natively t)
   (setq org-fontify-whole-heading-line t)
   (setq org-src-preserve-indentation t)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -12,6 +12,9 @@
 (use-package org
   :commands (org-mode)
   :mode (("\\.org\\'" . org-mode))
+  :bind
+  (:map org-mode-map
+        ([remap org-toggle-comment] . iedit-mode))
   :custom
   (org-todo-keywords
    '((sequence "TODO(t)" "WORK(w!/!)" "WAIT(a@/!)" "|" "DONE(d!/!)")))
@@ -54,7 +57,6 @@
        (emacs-lisp . t)
        (C          . t)
        (dot        . t)))))
-
 
 
 ;;; Show org-mode bullets as UTF-8 characters.

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -38,6 +38,26 @@
                 (make-local-variable 'flychek-disabled-checkers)
                 (add-to-list 'flycheck-disabled-checkers 'emacs-lisp-checkdoc)))
   (add-hook 'org-mode-hook #'turn-on-visual-line-mode)
+
+  (defun exordium--org-babel-after-execute ()
+    "Redisplay inline images in subtree if cursor in source block with :result graphics.
+
+Rationale:
+For some reason `org-babel-execute' is not producing images from .dot format (`org-version' 9.5.4).
+This is a spin off https://stackoverflow.com/a/66911315/519827, but REFRESH is set to nil."
+    (when (org-in-src-block-p)
+      (let (beg end)
+        (save-excursion
+          (org-mark-subtree)
+          (setq beg (point))
+          (setq end (mark)))
+        (when-let ((info (org-babel-get-src-block-info t))
+                   (params (org-babel-process-params (nth 2 info)))
+                   (result-params (cdr (assq :result params)))
+                   ((string-match-p "graphics" result-params)))
+          (org-display-inline-images nil nil beg end)))))
+  (add-hook 'org-babel-after-execute-hook #'exordium--org-babel-after-execute)
+
   ;; TODO: delete `exordium-enable-org-export'??
   (when exordium-enable-org-export
     ;; Enable org-babel for perl, ruby, sh, python, emacs-lisp, C, C++, etc

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -25,18 +25,21 @@
   (org-src-fontify-natively t)
   (org-fontify-whole-heading-line t)
   (org-src-preserve-indentation t)
-  ;; Turn off the confirmation for code eval when using org-babel
-  (org-confirm-babel-evaluate (not exordium-no-org-babel-confirm))
+  (org-confirm-babel-evaluate (not exordium-no-org-babel-confirm)
+                              "Turn off the confirmation for code eval when using org-babel.")
+  (org-html-htmlize-output-type (if exordium-org-export-css
+                                    'css
+                                  org-html-htmlize-output-type)
+                                "Configure export using a css style sheet")
+  (org-html-head (if exordium-org-export-css
+                     exordium-org-export-css-stylesheet
+                   org-html-head)
+                 "Configure export using a css style sheet")
   :config
-  (when exordium-enable-org-export
-    ;; Configure export using a css style sheet
-    (when exordium-org-export-css
-      (setq org-html-htmlize-output-type 'css)
-      (setq org-html-head exordium-org-export-css-stylesheet)))
-
-  (setq org-support-shift-select t)
+  ;; TODO: delete `exordium-enable-org-export'??
   (when exordium-enable-org-export
     ;; Enable org-babel for perl, ruby, sh, python, emacs-lisp, C, C++, etc
+    ;; TODO: add extra languages configurable by user
     (org-babel-do-load-languages
      'org-babel-load-languages
      `((perl       . t)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -8,6 +8,10 @@
 (defface exordium-org-work '((t (:inherit org-todo)))
   "Face for WORK keywords."
   :group 'exordium)
+(defface exordium-org-stop '((t (:inherit org-done)))
+  "Face for STOP keywords."
+  :group 'exordium)
+
 
 (use-package org
   :commands (org-mode)
@@ -17,10 +21,11 @@
         ([remap org-toggle-comment] . iedit-mode))
   :custom
   (org-todo-keywords
-   '((sequence "TODO(t)" "WORK(w!/!)" "WAIT(a@/!)" "|" "DONE(d!/!)")))
+   '((sequence "TODO(t)" "WORK(w!/!)" "WAIT(a@/!)" "|" "STOP(s@/!)" "DONE(d!/!)")))
   (org-todo-keyword-faces
    '(("WORK" . exordium-org-work)
-     ("WAIT" . exordium-org-wait)))
+     ("WAIT" . exordium-org-wait)
+     ("STOP" . exordium-org-stop)))
   (org-startup-folded t)
   (org-log-into-drawer t)
   (org-startup-truncated nil)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -1,18 +1,17 @@
 ;;;; Org mode
 
 (require 'init-prefs)
+
+(defface exordium-org-wait '((t (:inherit org-todo)))
+  "Face for WAIT keywords."
+  :group 'exordium)
+(defface exordium-org-work '((t (:inherit org-todo)))
+  "Face for WORK keywords."
+  :group 'exordium)
+
 (use-package org
   :commands (org-mode)
   :mode (("\\.org\\'" . org-mode))
-  :init
-  (add-hook 'org-mode-hook 'turn-on-visual-line-mode)
-  (defface exordium-org-wait '((t (:inherit org-todo)))
-    "Face for WAIT keywords."
-    :group 'exordium)
-  (defface exordium-org-work '((t (:inherit org-todo)))
-    "Face for WORK keywords."
-    :group 'exordium)
-
   :custom
   (org-todo-keywords
    '((sequence "TODO(t)" "WORK(w!/!)" "WAIT(a@/!)" "|" "DONE(d!/!)")))

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -57,21 +57,18 @@
   :hook
   (org-mode . (lambda () (org-superstar-mode 1))))
 
-;;; visual line mode in org-mode, paragraphs without embedded newline
-
-;; use ido for org completion
+(use-package ox-html
+  :ensure org
+  :after (org))
 
 (use-package ox-html
   :ensure org
   :after (org)
+  :if exordium-org-export-css
   :custom
-  (org-html-htmlize-output-type (if exordium-org-export-css
-                                    'css
-                                  org-html-htmlize-output-type)
+  (org-html-htmlize-output-type 'css
                                 "Configure export using a css style sheet")
-  (org-html-head (if exordium-org-export-css
-                     exordium-org-export-css-stylesheet
-                   org-html-head)
+  (org-html-head exordium-org-export-css-stylesheet
                  "Configure export using a css style sheet"))
 
 (use-package ox-md
@@ -98,6 +95,5 @@
   :ensure t
   :after (org)
   :if exordium-enable-org-export)
-
 
 (provide 'init-org)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -27,6 +27,7 @@
   (org-startup-with-inline-images t)
   (org-src-fontify-natively t)
   (org-fontify-whole-heading-line t)
+  (org-fontify-quote-and-verse-blocks t)
   (org-src-preserve-indentation t)
   (org-confirm-babel-evaluate (not exordium-no-org-babel-confirm)
                               "Turn off the confirmation for code eval when using org-babel.")

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -19,6 +19,7 @@
   (org-todo-keyword-faces
    '(("WORK" . exordium-org-work)
      ("WAIT" . exordium-org-wait)))
+  (org-log-into-drawer t)
   (org-startup-truncated nil)
   (org-startup-with-inline-images t)
   (org-src-fontify-natively t)

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -6,31 +6,28 @@
   :mode (("\\.org\\'" . org-mode))
   :init
   (add-hook 'org-mode-hook 'turn-on-visual-line-mode)
-
-  :config
   (defface exordium-org-wait '((t (:inherit org-todo)))
     "Face for WAIT keywords."
     :group 'exordium)
   (defface exordium-org-work '((t (:inherit org-todo)))
     "Face for WORK keywords."
     :group 'exordium)
-  (setq org-todo-keyword-faces
-        '(("WORK" . exordium-org-work)
-          ("WAIT" . exordium-org-wait)))
-  (setq org-todo-keywords
-        '((sequence "TODO" "WORK" "WAIT" "DONE")))
 
-  (setq org-startup-truncated nil)
-  (setq org-startup-with-inline-images t)
-  (setq org-src-fontify-natively t)
-  (setq org-fontify-whole-heading-line t)
-  (setq org-src-preserve-indentation t)
-  (setq org-completion-use-ido t)
+  :custom
+  (org-todo-keywords
+   '((sequence "TODO(t)" "WORK(w!/!)" "WAIT(a@/!)" "|" "DONE(d!/!)")))
+  (org-todo-keyword-faces
+   '(("WORK" . exordium-org-work)
+     ("WAIT" . exordium-org-wait)))
+  (org-startup-truncated nil)
+  (org-startup-with-inline-images t)
+  (org-src-fontify-natively t)
+  (org-fontify-whole-heading-line t)
+  (org-src-preserve-indentation t)
+  ;; Turn off the confirmation for code eval when using org-babel
+  (org-confirm-babel-evaluate (not exordium-no-org-babel-confirm))
+  :config
   (when exordium-enable-org-export
-    ;; Turn off the confirmation for code eval when using org-babel
-    (when exordium-no-org-babel-confirm
-      (setq org-confirm-babel-evaluate nil))
-
     ;; Configure export using a css style sheet
     (when exordium-org-export-css
       (setq org-html-htmlize-output-type 'css)

--- a/themes/color-theme-github-modern.el
+++ b/themes/color-theme-github-modern.el
@@ -900,6 +900,7 @@ names to which it refers are bound."
      (org-todo ((t (:bold t :foreground ,github-string :weight bold))))
      (exordium-org-work ((t (:foreground ,github-function :weight bold :box nil))))
      (exordium-org-wait ((t (:foreground ,github-constant :weight bold :box nil))))
+     (exordium-org-stop ((t (:bold t :weight bold :foreground ,github-comment))))
      (org-upcoming-deadline ((t (:inherit font-lock-keyword-face))))
      (org-warning ((t (:bold t :foreground ,github-string :weight bold :underline nil))))
      (org-column ((t (:background ,github-selection))))

--- a/themes/color-theme-github-modern.el
+++ b/themes/color-theme-github-modern.el
@@ -898,6 +898,8 @@ names to which it refers are bound."
      (org-tag ((t (:bold t :weight bold))))
      (org-time-grid ((t (:foreground ,github-text))))
      (org-todo ((t (:bold t :foreground ,github-string :weight bold))))
+     (exordium-org-work ((t (:foreground ,github-function :weight bold :box nil))))
+     (exordium-org-wait ((t (:foreground ,github-constant :weight bold :box nil))))
      (org-upcoming-deadline ((t (:inherit font-lock-keyword-face))))
      (org-warning ((t (:bold t :foreground ,github-string :weight bold :underline nil))))
      (org-column ((t (:background ,github-selection))))
@@ -1254,17 +1256,6 @@ names to which it refers are bound."
   (with-github-colors
    (apply 'custom-theme-set-variables 'github-modern (github-variables)))
   (provide-theme 'github-modern))
-
-;;; Extra functions
-
-(defun set-github-extra-org-statuses ()
-  (require 'org)
-  (with-github-colors
-   (setq org-todo-keyword-faces
-         `(("WORK" . (:foreground ,github-function
-                      :weight bold :box nil))
-           ("WAIT" . (:foreground ,github-constant
-                      :weight bold :box nil))))))
 
 ;;; Debugging functions
 

--- a/themes/color-theme-material.el
+++ b/themes/color-theme-material.el
@@ -304,6 +304,8 @@ names to which it refers are bound."
      (org-special-keyword ((t (:foreground ,comment))))
      (org-table ((t (:foreground ,light-blue-50 :background ,far-background))))
      (org-todo ((t (:foreground ,deep-orange-200 :bold t :background ,deep-orange-a700))))
+     (exordium-org-work ((t (:foreground ,yellow :background ,deep-orange-a700 :weight bold :box nil))))
+     (exordium-org-wait ((t (:foreground ,orange :background ,deep-orange-a700 :weight bold :box nil))))
      (org-upcoming-deadline ((t (:foreground ,orange))))
      (org-warning ((t (:weight bold :foreground ,red))))
      (org-block-begin-line ((t (:foreground ,light-blue-100 :underline ,light-blue-50))))
@@ -461,18 +463,6 @@ names to which it refers are bound."
    (apply 'custom-theme-set-faces 'material (material-face-specs)))
   (provide-theme 'material))
 
-;; Extra functions
-
-(defun set-material-extra-org-statuses ()
-  (require 'org)
-  (with-material-colors
-   (setq org-todo-keyword-faces
-         `(("WORK" . (;:background ,yellow
-                      :foreground ,yellow :background ,deep-orange-a700
-                      :weight bold :box nil))
-           ("WAIT" . (;:background ,orange
-                      :foreground ,orange :background ,deep-orange-a700
-                      :weight bold :box nil))))))
 
 ;;; Debugging functions
 

--- a/themes/color-theme-material.el
+++ b/themes/color-theme-material.el
@@ -306,6 +306,7 @@ names to which it refers are bound."
      (org-todo ((t (:foreground ,deep-orange-200 :bold t :background ,deep-orange-a700))))
      (exordium-org-work ((t (:foreground ,yellow :background ,deep-orange-a700 :weight bold :box nil))))
      (exordium-org-wait ((t (:foreground ,orange :background ,deep-orange-a700 :weight bold :box nil))))
+     (exordium-org-stop ((t (:foreground ,light-green-400 :bold t :background ,green-900))))
      (org-upcoming-deadline ((t (:foreground ,orange))))
      (org-warning ((t (:weight bold :foreground ,red))))
      (org-block-begin-line ((t (:foreground ,light-blue-100 :underline ,light-blue-50))))

--- a/themes/color-theme-monokai.el
+++ b/themes/color-theme-monokai.el
@@ -507,6 +507,10 @@ names to which it refers are bound."
       ((t (:foreground ,monokai-comments))))
      (org-todo
       ((t (:foreground ,red :weight bold))))
+     (exordium-org-work
+      ((t (:foreground ,yellow :weight bold :box nil))))
+     (exordium-org-wait
+      ((t (:foreground ,orange :weight bold :box nil))))
      (org-upcoming-deadline
       ((t (:foreground ,yellow :weight normal :underline nil))))
      (org-warning
@@ -576,14 +580,6 @@ names to which it refers are bound."
    'default
    (apply 'custom-theme-set-faces 'monokai (monokai-face-specs)))
   (provide-theme 'monokai))
-
-(defun set-monokai-extra-org-statuses ()
-  "Set colors for WORK and WAIT org statuses"
-  (with-monokai-colors
-        'default
-        (setq org-todo-keyword-faces
-              `(("WORK" . (:foreground ,yellow :weight bold :box nil))
-                ("WAIT" . (:foreground ,orange :weight bold :box nil))))))
 
 ;;; Debugging functions
 

--- a/themes/color-theme-monokai.el
+++ b/themes/color-theme-monokai.el
@@ -511,6 +511,8 @@ names to which it refers are bound."
       ((t (:foreground ,yellow :weight bold :box nil))))
      (exordium-org-wait
       ((t (:foreground ,orange :weight bold :box nil))))
+     (exordium-org-stop
+      ((t (:weight bold :foreground ,blue))))
      (org-upcoming-deadline
       ((t (:foreground ,yellow :weight normal :underline nil))))
      (org-warning

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -339,6 +339,10 @@ names to which it refers are bound."
 
      ;; magit and forge
      (forge-topic-closed ((t (:foreground ,base00))))
+
+     ;; iedit
+     (iedit-occurrence ((t (:box ,base0))))
+     (iedit-read-only-occurrence ((t (:box ,base01))))
      )))
 
 (defmacro define-solarized-theme (mode)

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -203,12 +203,14 @@ names to which it refers are bound."
 
      ;; Org
      (org-hide ((t (:foreground ,base03))))
-     (org-todo ((t (:weight bold :foreground ,base03 :background ,red))))
+     (org-todo ((t (:weight bold :foreground ,red))))
      (org-done ((t (:weight bold :foreground ,green))))
+     (exordium-org-wait ((t (:weight bold :foreground ,yellow ))))
+     (exordium-org-work ((t (:weight bold :foreground ,orange))))
      (org-meta-line ((t (:background ,base02 :slant italic :box t))))
      (org-block ((t (:background ,back))))
      (org-code ((t (:foreground ,cyan :background ,back))))
-     (org-verbatim ((t (:background ,base02))))
+     (org-verbatim ((t (:background ,back))))
      (org-todo-kwd-face ((t (:foreground ,red :background ,base03))))
      (org-done-kwd-face ((t (:foreground ,green :background ,base03))))
      (org-project-kwd-face ((t (:foreground ,violet :background ,base03))))
@@ -363,15 +365,12 @@ names to which it refers are bound."
   "Return the mode without the solarized- prefix, e.g. dark or light."
   (intern (substring (symbol-name exordium-theme) 10)))
 
+;; TODO: rename me and use a standard
 (defun set-solarized-extra-org-statuses ()
   "Set colors for WORK and WAIT org statuses"
   (with-solarized-colors
    (solarized-mode-name)
-   (setq org-todo-keyword-faces
-         `(("WORK" . (:background ,yellow :foreground ,back
-                      :weight bold :box nil))
-           ("WAIT" . (:background ,orange :foreground ,back
-                                  :weight bold :box nil))))
+   ;; TODO: but this should go to a common bit in exordium within `use-package' and `markdown'
    (when exordium-theme-use-big-font
      (custom-set-variables
       '(markdown-header-scaling-values `(,exordium-height-plus-4

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -66,6 +66,7 @@ names to which it refers are bound."
      (shadow ((t (:background ,base01))))
      (success ((t (:foreground ,green))))
      (error ((t (:weight bold :foreground ,red))))
+     (next-error ((t (:background ,magenta))))
      (warning ((t (:weight bold :foreground ,orange))))
      (scroll-bar ((t (:background ,back))))
 

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -207,6 +207,7 @@ names to which it refers are bound."
      (org-done ((t (:weight bold :foreground ,green))))
      (exordium-org-wait ((t (:weight bold :foreground ,yellow ))))
      (exordium-org-work ((t (:weight bold :foreground ,orange))))
+     (exordium-org-stop ((t (:weight bold :foreground ,blue))))
      (org-meta-line ((t (:background ,base02 :slant italic :box t))))
      (org-block ((t (:background ,back))))
      (org-code ((t (:foreground ,cyan :background ,back))))

--- a/themes/color-theme-solarized.el
+++ b/themes/color-theme-solarized.el
@@ -190,11 +190,24 @@ names to which it refers are bound."
                                   `(:underline (:color ,green :style wave))))))
      (rtags-skippedline ((t (:background ,base01))))
 
+     ;; outline
+     (outline-1 ((t (:foreground ,blue))))
+     (outline-2 ((t (:foreground ,cyan))))
+     (outline-3 ((t (:foreground ,yellow))))
+     (outline-4 ((t (:foreground ,red))))
+     (outline-5 ((t (:foreground ,orange))))
+     (outline-6 ((t (:foreground ,violet))))
+     (outline-7 ((t (:foreground ,base0))))
+     (outline-8 ((t (:foreground ,base01))))
+
      ;; Org
      (org-hide ((t (:foreground ,base03))))
      (org-todo ((t (:weight bold :foreground ,base03 :background ,red))))
      (org-done ((t (:weight bold :foreground ,green))))
-     (org-block ((t (:foreground ,base01 :background ,base02))))
+     (org-meta-line ((t (:background ,base02 :slant italic :box t))))
+     (org-block ((t (:background ,back))))
+     (org-code ((t (:foreground ,cyan :background ,back))))
+     (org-verbatim ((t (:background ,base02))))
      (org-todo-kwd-face ((t (:foreground ,red :background ,base03))))
      (org-done-kwd-face ((t (:foreground ,green :background ,base03))))
      (org-project-kwd-face ((t (:foreground ,violet :background ,base03))))
@@ -203,23 +216,29 @@ names to which it refers are bound."
      (org-started-kwd-face ((t (:foreground ,yellow :background ,base03))))
      (org-cancelled-kwd-face ((t (:foreground ,green :background ,base03))))
      (org-delegated-kwd-face ((t (:foreground ,cyan :background ,base03))))
-     (org-document-title ((t
-                           ,(append `(:weight bold :foreground ,cyan)
-                                    (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
-     (org-level-1 ((t
-                    ,(append `(:foreground ,base0
-                               :overline ,base0)
-                             (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))
+     (org-document-title ((t (:weight bold :foreground ,cyan
+                                      ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-4))))))
+     (org-level-1 ((t (:inherit outline-1 :overline ,blue
+                                   ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-3))))))
+     (org-level-2 ((t (:inherit outline-2
+                                  ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-2))))))
+     (org-level-3 ((t (:inherit outline-3
+                                  ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-1))))))
 
-     ;; outline
-     (outline-1 ((t (:foreground ,blue))))
-     (outline-2 ((t (:foreground ,cyan))))
-     (outline-3 ((t (:foreground ,yellow))))
-     (outline-4 ((t (:foreground ,red))))
-     (outline-5 ((t (:foreground ,base0))))
-     (outline-6 ((t (:foreground ,base01))))
-     (outline-7 ((t (:foreground ,orange))))
-     (outline-8 ((t (:foreground ,violet))))
+
+     ;; rst - reStructuredText-documents
+     (rst-level-1 ((t (:inherit outline-1
+                                ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-3))))))
+     (rst-level-2 ((t (:inherit outline-2
+                                ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-2))))))
+     (rst-level-3 ((t (:inherit outline-3
+                                ,@(when exordium-theme-use-big-font `(:height ,exordium-height-plus-1))))))
+     (rst-level-4 ((t (:inherit outline-4))))
+     (rst-level-5 ((t (:inherit outline-5))))
+     (rst-level-6 ((t (:inherit outline-6))))
+
+     ;; markdown
+     (markdown-markup-face ((t (:foreground ,cyan :background ,back :slant normal :weight normal))))
 
      ;; Flymake
      (flymake-errline ((t (:weight bold :foreground ,red :background ,back))))
@@ -347,7 +366,16 @@ names to which it refers are bound."
          `(("WORK" . (:background ,yellow :foreground ,back
                       :weight bold :box nil))
            ("WAIT" . (:background ,orange :foreground ,back
-                      :weight bold :box nil))))))
+                                  :weight bold :box nil))))
+   (when exordium-theme-use-big-font
+     (custom-set-variables
+      '(markdown-header-scaling-values `(,exordium-height-plus-4
+                                         ,exordium-height-plus-3
+                                         ,exordium-height-plus-2
+                                         ,exordium-height-plus-1
+                                         1.0
+                                         1.0))
+      '(markdown-header-scaling t)))))
 
 ;;; Debugging functions
 

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -352,7 +352,8 @@ names to which it refers are bound."
                                     (if exordium-theme-use-big-font `(:height ,exordium-height-plus-10) nil)))))
      (org-todo ((t (:foreground ,red :weight bold :box nil))))
      (org-done ((t (:foreground ,green :weight bold :box nil))))
-     (org-headline-done ((t (:foreground ,comment :box nil))))
+     (exordium-org-wait ((t (:foreground ,yellow :weight bold :box nil))))
+     (exordium-org-work ((t (:foreground ,orange :weight bold :box nil))))
      (org-checkbox ((t (:background ,selection :foreground ,yellow :weight bold))))
      (org-ellipsis ((t (:foreground ,comment))))
      (org-footnote ((t (:foreground ,aqua))))
@@ -532,17 +533,6 @@ names to which it refers are bound."
 (defun tomorrow-mode-name ()
   "Return the mode without the tomorrow- prefix, e.g. day, night etc."
   (intern (substring (symbol-name exordium-theme) 9)))
-
-(defun set-tomorrow-extra-org-statuses ()
-  (with-tomorrow-colors
-   (tomorrow-mode-name)
-   (setq org-todo-keyword-faces
-         `(("WORK" . (;:background ,yellow
-                      :foreground ,yellow
-                      :weight bold :box nil))
-           ("WAIT" . (;:background ,orange
-                      :foreground ,orange
-                      :weight bold :box nil))))))
 
 ;; Debugging functions
 

--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -354,6 +354,7 @@ names to which it refers are bound."
      (org-done ((t (:foreground ,green :weight bold :box nil))))
      (exordium-org-wait ((t (:foreground ,yellow :weight bold :box nil))))
      (exordium-org-work ((t (:foreground ,orange :weight bold :box nil))))
+     (exordium-org-stop ((t (:foreground ,blue :weight bold :box nil))))
      (org-checkbox ((t (:background ,selection :foreground ,yellow :weight bold))))
      (org-ellipsis ((t (:foreground ,comment))))
      (org-footnote ((t (:foreground ,aqua))))

--- a/themes/color-theme-zenburn.el
+++ b/themes/color-theme-zenburn.el
@@ -738,6 +738,7 @@ names to which it refers are bound."
      (org-todo ((t (:bold t :foreground ,zenburn-red :weight bold))))
      (exordium-org-work ((t (:foreground ,zenburn-yellow :weight bold :box nil))))
      (exordium-org-wait ((t (:foreground ,zenburn-orange :weight bold :box nil))))
+     (exordium-org-stop ((t (:foreground ,zenburn-green+1 :weight bold :box nil))))
      (org-upcoming-deadline ((t (:inherit font-lock-keyword-face))))
      (org-warning ((t (:bold t :foreground ,zenburn-red :weight bold :underline nil))))
      (org-column ((t (:background ,zenburn-bg-1))))

--- a/themes/color-theme-zenburn.el
+++ b/themes/color-theme-zenburn.el
@@ -736,6 +736,8 @@ names to which it refers are bound."
      (org-tag ((t (:bold t :weight bold))))
      (org-time-grid ((t (:foreground ,zenburn-orange))))
      (org-todo ((t (:bold t :foreground ,zenburn-red :weight bold))))
+     (exordium-org-work ((t (:foreground ,zenburn-yellow :weight bold :box nil))))
+     (exordium-org-wait ((t (:foreground ,zenburn-orange :weight bold :box nil))))
      (org-upcoming-deadline ((t (:inherit font-lock-keyword-face))))
      (org-warning ((t (:bold t :foreground ,zenburn-red :weight bold :underline nil))))
      (org-column ((t (:background ,zenburn-bg-1))))
@@ -939,19 +941,6 @@ names to which it refers are bound."
   (with-zenburn-colors
    (apply 'custom-theme-set-variables 'zenburn (zenburn-variables)))
   (provide-theme 'zenburn))
-
-;;; Extra functions
-
-(defun set-zenburn-extra-org-statuses ()
-  (require 'org)
-  (with-zenburn-colors
-   (setq org-todo-keyword-faces
-         `(("WORK" . (;:background ,zenburn-yellow
-                      :foreground ,zenburn-yellow
-                      :weight bold :box nil))
-           ("WAIT" . (;:background ,zenburn-orange
-                      :foreground ,zenburn-orange
-                      :weight bold :box nil))))))
 
 ;;; Debugging functions
 


### PR DESCRIPTION
This is a set of rather opinionated tunes and refactoring I've done to `org-mode`. This set contains multiple fixes, and I guess the best way to review it would be to commit by commit. In a broader stroke these include:
- Updates to solarized theme. I've not been using it for a while (for the favour of `modus-themes`), but this encapsulates my opinionated fixes to it. These were done in light version (which was my primary theme), so the dark one may be not up to date
- todo keywords: TODO, WORK, WAIT, DONE. I've chosen them such that they are nicely aligned with a proportional font. I've also added two custom faces for them, such that highlighting stays consistent.
- Refactor `org-mode` setup into relevant `use-package`s.
- A few fixes and improvements: sql in babel, more blocks highlighting, forcing pictures display, allow `iedit` (with the same keybinding as elsewhere).

Likely you'd like to update your config to this one and see how it gels with your workflow (if at all 😎).

Starting with draft to collect some feedback.