### PR TITLE
Use function quote for all :bind in use-package

### DIFF
--- a/modules/init-autocomplete.el
+++ b/modules/init-autocomplete.el
@@ -13,9 +13,9 @@
   (ac-config-default)
   :bind
   (;; Key to force trigger auto-complete (useful if ac-auto-start is set to nil)
-   ("C-." . auto-complete)
+   ("C-." . #'auto-complete)
    :map ac-completing-map
-        ("<escape>" . ac-stop)
-        ([return] . ac-complete)))
+        ("<escape>" . #'ac-stop)
+        ([return] . #'ac-complete)))
 
 (provide 'init-autocomplete)

--- a/modules/init-company.el
+++ b/modules/init-company.el
@@ -11,9 +11,9 @@
   (add-to-list 'company-backends '(company-capf company-dabbrev))
   (setq company-idle-delay nil)
   :bind
-  (("C-." . company-complete)
+  (("C-." . #'company-complete)
    :map company-active-map
-        ("<escape>" . company-abort)))
+        ("<escape>" . #'company-abort)))
 
 
 (use-package company-statistics

--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -23,7 +23,7 @@
 (use-package iedit
   :init
   ;;; Fix A bug (normal key is "C-;")
-  :bind ("C-c ;" . iedit-mode))
+  :bind ("C-c ;" . #'iedit-mode))
 
 ;;; Don't show the abbrev minor mode in the mode line
 (diminish 'abbrev-mode)

--- a/modules/init-docker.el
+++ b/modules/init-docker.el
@@ -1,7 +1,7 @@
 ;;;; Configuration of Docker related features
 
 (use-package docker
-  :bind ("C-c D" . docker))
+  :bind ("C-c D" . #'docker))
 
 
 (use-package dockerfile-mode

--- a/modules/init-forge.el
+++ b/modules/init-forge.el
@@ -105,12 +105,12 @@ USERNAME, AUTH, and HOST behave as for `ghub-request'."
                        (set-fill-column 1000)))
   :bind
   (:map forge-post-mode-map
-        ("C-c C-p" . exordium-forge-markdown-preview)
-        ("C-c C-d" . exordium-forge-post-submit-draft)
+        ("C-c C-p" . #'exordium-forge-markdown-preview)
+        ("C-c C-d" . #'exordium-forge-post-submit-draft)
    :map magit-status-mode-map
-        ("C-c C-d" . exordium-forge-mark-ready-for-rewiew)
+        ("C-c C-d" . #'exordium-forge-mark-ready-for-rewiew)
    :map forge-topic-mode-map
-        ("C-c C-d" . exordium-forge-mark-ready-for-rewiew)))
+        ("C-c C-d" . #'exordium-forge-mark-ready-for-rewiew)))
 
 (use-package async)
 (use-package cl-lib :ensure nil)

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -91,13 +91,13 @@ The function is meant to be used as an advice with conjunction with `exordium-ma
 
   :bind
   (:map exordium-git-map
-        ("s" . (function magit-status))
-        ("l" . exordium-magit-log)
-        ("f" . exordium-magit-log-buffer)
-        ("b" . exordium-magit-blame)
-        ("c" . (function magit-clone))
+        ("s" . #'magit-status)
+        ("l" . #'exordium-magit-log)
+        ("f" . #'exordium-magit-log-buffer)
+        ("b" . #'exordium-magit-blame)
+        ("c" . #'magit-clone)
    :map magit-status-mode-map
-        ("q" . exordium-magit-quit-session))
+        ("q" . #'exordium-magit-quit-session))
 
   :hook
   (magit-status-mode . exordium-magit--dont-insert-symbol-for-search)
@@ -189,7 +189,7 @@ The function is meant to be used as an advice with conjunction with `exordium-ma
   :ensure nil
   :bind
   (:map smerge-mode-map
-        ("C-c ^ d" . exordium-smerge-dispatch)))
+        ("C-c ^ d" . #'exordium-smerge-dispatch)))
 
 (defun exordium-smerge-dispatch-maybe ()
   "Display `exordium-smerge-dispatch' when buffer is in `smerge-mode'."
@@ -254,7 +254,7 @@ The function is meant to be used as an advice with conjunction with `exordium-ma
   :defer t
   :bind
   (:map exordium-git-map
-        ("t" . git-timemachine-toggle)))
+        ("t" . #'git-timemachine-toggle)))
 
 
 ;;; Git Grep

--- a/modules/init-helm-projectile.el
+++ b/modules/init-helm-projectile.el
@@ -23,7 +23,7 @@
   :diminish
   :bind
   (:map projectile-command-map
-        ("." . helm-projectile-find-file-dwim))
+        ("." . #'helm-projectile-find-file-dwim))
   :bind-keymap
   ("C-c p" . projectile-command-map)
   :config
@@ -69,17 +69,17 @@ project's file using completion and show it in another window."
       (projectile-switch-project)))
 
   :bind
-  (("C-c h"   . helm-projectile)
-   ("C-c H"   . helm-projectile-switch-project)
-   ("C-c M-h" . helm-projectile-switch-project)
-   ("C-S-a"   . helm-projectile-ag)
-   ("C-S-r"   . helm-projectile-rg)
+  (("C-c h"   . #'helm-projectile)
+   ("C-c H"   . #'helm-projectile-switch-project)
+   ("C-c M-h" . #'helm-projectile-switch-project)
+   ("C-S-a"   . #'helm-projectile-ag)
+   ("C-S-r"   . #'helm-projectile-rg)
    :map helm-projectile-projects-map
-        ("C-S-a" . exordium-helm-projectile--exit-helm-and-do-ag)
-        ("C-S-r" . exordium-helm-projectile--exit-helm-and-do-rg)
+        ("C-S-a" . #'exordium-helm-projectile--exit-helm-and-do-ag)
+        ("C-S-r" . #'exordium-helm-projectile--exit-helm-and-do-rg)
    :map projectile-command-map
-        ("p" . helm-projectile-switch-project)
-        ("4 p" . exordium-projectile-switch-project-find-file-other-window))
+        ("p" . #'helm-projectile-switch-project)
+        ("4 p" . #'exordium-projectile-switch-project-find-file-other-window))
 
   :config
   (helm-add-action-to-source "Silver Searcher (ag) in project `C-S-a'"
@@ -94,7 +94,7 @@ project's file using completion and show it in another window."
 
 (use-package treemacs-projectile
   :bind
-  (("C-c e" . treemacs)
-   ("C-c E" . treemacs-projectile)))
+  (("C-c e" . #'treemacs)
+   ("C-c E" . #'treemacs-projectile)))
 
 (provide 'init-helm-projectile)

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -40,10 +40,10 @@
   (history-delete-duplicates t)
   (helm-M-x-always-save-history t)
   :bind
-  (([remap execute-extended-command] . helm-M-x) ; M-x
-   ([remap yank-pop] . helm-show-kill-ring) ; M-y
-   ([remap find-file] . helm-find-files) ; C-x C-f
-   ([remap find-file-read-only] . helm-recentf)) ; C-x C-r
+  (([remap execute-extended-command] . #'helm-M-x) ; M-x
+   ([remap yank-pop] . #'helm-show-kill-ring) ; M-y
+   ([remap find-file] . #'helm-find-files) ; C-x C-f
+   ([remap find-file-read-only] . #'helm-recentf)) ; C-x C-r
   :config
   ;; Do not show these files in helm buffer
   (add-to-list 'helm-boring-file-regexp-list "\\.tsk$")
@@ -52,35 +52,35 @@
 
 (use-package helm-descbinds
   :bind
-  (("C-h b" . helm-descbinds)))
+  (("C-h b" . #'helm-descbinds)))
 
 (use-package helm-ag
   :custom
   (helm-ag-insert-at-point 'symbol)
   :bind
-  (("C-S-d" . helm-do-ag)
-   ("C-S-f" . helm-do-ag-this-file)))
+  (("C-S-d" . #'helm-do-ag)
+   ("C-S-f" . #'helm-do-ag-this-file)))
 
 (use-package helm-ag
   :unless exordium-helm-projectile
   :bind
-  (("C-S-a" . helm-ag-project-root)))
+  (("C-S-a" . #'helm-ag-project-root)))
 
 (use-package helm-rg
   :unless exordium-helm-projectile
   :bind
-  (("C-S-r" . helm-rg)))
+  (("C-S-r" . #'helm-rg)))
 
 (use-package helm-swoop
   :custom
   (helm-swoop-split-direction 'split-window-horizontally)
   :bind
-  (("C-S-s" . helm-swoop)
+  (("C-S-s" . #'helm-swoop)
    ;; Use similar bindings to `helm-ag-edit'
    :map helm-swoop-edit-map
-        ("C-c C-c" . helm-swoop--edit-complete)
-        ("C-c C-k" . helm-swoop--edit-cancel)
-        ("C-c C-q C-k" . helm-swoop--edit-delete-all-lines)))
+        ("C-c C-c" . #'helm-swoop--edit-complete)
+        ("C-c C-k" . #'helm-swoop--edit-cancel)
+        ("C-c C-q C-k" . #'helm-swoop--edit-delete-all-lines)))
 
 
 

--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -26,7 +26,7 @@
   :ensure nil
   :bind
   (:map help-mode-map
-        ("C-c C-o" . exordium-browse-url-at-point)))
+        ("C-c C-o" . #'exordium-browse-url-at-point)))
 
 
 (use-package page-break-lines
@@ -39,24 +39,24 @@
   (;; Note that the built-in `describe-function' includes both functions
    ;; and macros. `helpful-function' is functions only, so we provide
    ;; `helpful-callable' as a drop-in replacement.
-   ("C-h f" . helpful-callable)
+   ("C-h f" . #'helpful-callable)
    ;; Look up *F*unctions (excludes macros).
    ;; By default, C-h F is bound to `Info-goto-emacs-command-node'. Helpful
    ;; already links to the manual, if a function is referenced there.
-   ("C-h F" . helpful-function)
-   ("C-h v" . helpful-variable)
-   ("C-h k" . helpful-key)
+   ("C-h F" . #'helpful-function)
+   ("C-h v" . #'helpful-variable)
+   ("C-h k" . #'helpful-key)
    ;; Look up *C*ommands.
    ;; By default, C-h C is bound to describe `describe-coding-system'.
    ;; Apparently it's frequently useful to only look at interactive functions.
-   ("C-h C" . helpful-command)
+   ("C-h C" . #'helpful-command)
    ;; Lookup the current symbol at point. C-c C-d is a common keybinding
    ;; for this in lisp modes.
    :map emacs-lisp-mode-map
-        ("C-c C-d" . helpful-at-point)
+        ("C-c C-d" . #'helpful-at-point)
    :map helpful-mode-map
-        ("C-c C-d" . helpful-at-point)
-        ("C-c C-o" . exordium-browse-url-at-point)))
+        ("C-c C-d" . #'helpful-at-point)
+        ("C-c C-o" . #'exordium-browse-url-at-point)))
 
 (use-package helm
   :diminish

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -270,7 +270,7 @@ With argument, do this that many times."
   :if exordium-fci-mode
   :ensure nil
   :demand t
-  :bind ("C-|" . display-fill-column-indicator-mode)
+  :bind ("C-|" . #'display-fill-column-indicator-mode)
   :init
   (defun exordium--select-display-fill-column-indicator-character ()
     (cl-flet


### PR DESCRIPTION
This is a followup to #204. N.B., while the original issue manifested on emacs-27.2 with @matthewpersico's personal customisation on Linux, I can see the issue that caused customisation to fail to load on my emacs-28.3-rc1 on my Mac. That is: without quoting (as fixed in #204) the `fringe-helper-define` is not defined. With quoting it is defined.

The original idea was to have the same syntax for all bindings. Unfortunately, the simplest form (just function symbol name) does not always work and fails in subtle ways. I decided to use a short version of [`function`](https://www.gnu.org/software/emacs/manual/html_node/elisp/Anonymous-Functions.html#index-function) everywhere to avoid surprises like the aforementioned one.