### PR TITLE
Add forge dependency: sqlite3

### DIFF
--- a/.ci/unit-test-cl.sh
+++ b/.ci/unit-test-cl.sh
@@ -8,8 +8,8 @@ EMACS="${EMACS:=emacs}"
 ${EMACS} -Q --batch \
          --eval '
 (progn
-   (setq debug-on-error t
-         user-emacs-directory "'${EMACS_DIR}'")
+   (setq user-emacs-directory "'${EMACS_DIR}'")
    (load-file "'${EMACS_DIR}'/init.el")
+   (setq debug-on-error t)
    (load-file "'${EMACS_DIR}'/modules/init-util-cl.t.el")
    (ert-run-tests-batch-and-exit))'

--- a/modules/init-forge.el
+++ b/modules/init-forge.el
@@ -9,7 +9,13 @@
 ;;;                   (in `magit-status-mode' and in `forge-topic-mode')
 
 
-
+;; `emacsql' (a dependency of `forge') requires sqlite3 support. How the
+;; support is provided changes with emacs-29 (i.e., built-in). See
+;; https://github.com/magit/emacsql/commit/6401226 for more details.
+(unless (and (fboundp 'sqlite-available-p)
+             (sqlite-available-p))
+ (use-package sqlite3))
+
 ;;; Magit Forge
 (use-package forge
   :defer t


### PR DESCRIPTION
IIUC, `forge` requires a `sqlite3` backend. It's up to user to ensure it's there: built in (default for Emacs 29), or extra package if not.  See the in-code comments for more details.

Caveats:
- The `debug-on-error` has to be `nil` when loading `/init.el`, since our current CI doesn't come with `sqlite3` library (https://github.com/purcell/nix-emacs-ci/issues/160). I moved it for `unit-test-cl.sh` since it's required for the tests to fail when deprecated functions are used.
- Not sure how to communicate this to users, that they need to come up with a properly configured OS (i.e, with `libsqlite3` available) or Emacs 29.