### PR TITLE
Add exordium-company-assignees to complete in forge repositories

### DIFF
--- a/modules/init-company.el
+++ b/modules/init-company.el
@@ -2,14 +2,56 @@
 
 (use-package company
   :diminish "CA"
-  :after (rtags)
+  :after (rtags forge)
   :defer
+
+  :init
+  (defun exordium-company-assignees (command &optional arg &rest ignored)
+  "A `company-mode' backend for assigneees in `forge-mode' repository."
+  (interactive (list 'interactive))
+  (cl-case command
+    (interactive (company-begin-backend 'exordium-company-assignees))
+    (prefix
+     (save-match-data
+       (when (and (or (and (boundp 'git-commit-mode)
+                           git-commit-mode)
+                      (derived-mode-p 'forge-post-mode))
+                  (forge-get-repository 'full)
+                  (looking-back
+                   "@\\([a-z0-9]\\(?:[a-z0-9]\\|[-/]\\(?:[a-z0-9]\\)\\)\\{0,38\\}\\)?"
+                   (max (- (point) 40)
+                        (point-at-bol))))
+         ;; IDK how to match end of a 'symbol' that is equal to an "@" or is
+         ;; equal to "@foo" in neither `git-commit-mode' nor
+         ;; `forge-post-mode'. Hence it's handled manually.  The `looking-back'
+         ;; above matches an "@" or an "@foo". When it was the latter there was
+         ;; a match in group 1.  Now, check if this is at the very end of the
+         ;; "@" or "@foo".  Note that "@<point>@" also matches. Probably a few
+         ;; other characters, substituting the second "@" in latter pattern,
+         ;; would also give a positive result. Yet, in such a case the `match'
+         ;; is "", so that's all fine - all candidates will be shown.
+         (when (or (save-match-data (looking-at "\\W"))
+                   (= (point) (point-max)))
+           (cons (or (match-string 1) "") t)))))
+    (candidates (when-let ((repo (forge-get-repository 'full)))
+                  (cl-remove-if-not
+                   (lambda (assignee)
+                     (string-prefix-p arg assignee))
+                   (mapcar (lambda (assignee)
+                             (propertize (cadr assignee)
+                                         'full-name (caddr assignee)))
+                           (oref repo assignees)))))
+    (annotation (when-let ((assignee (get-text-property 0 'full-name arg)))
+                  (format " [%s]" assignee)))))
+
   :config
   (setq rtags-completions-enabled t)
   ;; Turn on company mode everywhere
   (global-company-mode)
   (add-to-list 'company-backends '(company-capf company-dabbrev))
+  (add-to-list 'company-backends 'exordium-company-assignees)
   (setq company-idle-delay nil)
+
   :bind
   (("C-." . #'company-complete)
    :map company-active-map


### PR DESCRIPTION
This allows for completing mentions in commit messages as well as in new issues and PRs in forge mode.

The backend is inspired by (this tutorial)[https://sixty-north.com/blog/writing-the-simplest-emacs-company-mode-backend.html].