### PR TITLE
Avoid docker-tramp when emacs >= 29

### DIFF
--- a/modules/init-docker.el
+++ b/modules/init-docker.el
@@ -12,6 +12,6 @@
 
 (use-package docker-tramp
   :defer t
-  :when (version<=  emacs-version "29"))
+  :when (version<  emacs-version "29"))
 
 (provide 'init-docker)

--- a/modules/init-docker.el
+++ b/modules/init-docker.el
@@ -10,6 +10,8 @@
   :config
   (setq-default docker-use-sudo nil))
 
-(use-package docker-tramp)
+(use-package docker-tramp
+  :defer t
+  :when (version<=  emacs-version "29"))
 
 (provide 'init-docker)


### PR DESCRIPTION
Facility is now built into emacs 29.