### PR TITLE
Enable more treesit modes in Emacs 29 and add Emacs 29 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ jobs:
           - 27.2
           - 28.1
           - 28.2
+          - 29.1
           - snapshot
     steps:
       - uses: purcell/setup-emacs@master
@@ -50,7 +51,9 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            emacs_version: 28.2
+            emacs_version: 27.2
+          - os: macos-latest
+            emacs_version: 29.1
           - os: macos-latest
             emacs_version: snapshot
     steps:

--- a/modules/init-treesit.el
+++ b/modules/init-treesit.el
@@ -30,15 +30,25 @@
             (mapc #'exordium--add-forward-ts-hook
                   '(
                     LaTeX
+                    bash
                     c
                     c++
-                    java
+                    cmake
+                    csharp
+                    css
                     go
+                    go-mod
+                    java
+                    js
+                    json
                     markdown
                     python
                     ruby
                     rust
                     scala
+                    toml
+                    typescript
+                    yaml
                     ))
             (setq treesit-font-lock-level 4)))
 


### PR DESCRIPTION
Scanned what `-ts-mode` were available in my Emacs-29 and added forwarding hooks for them.

Also enable CI for Emacs-29, as I presume the snapshot will be drifting away from there.