### PR TITLE
Don't depend on lsp-mode for treesit

### DIFF
--- a/modules/init-treesit.el
+++ b/modules/init-treesit.el
@@ -5,10 +5,10 @@
 (defun exordium--add-forward-ts-hook (mode)
   (when-let ((ts-hook (intern (concat (symbol-name mode) "-ts-mode-hook")))
              (hook (intern (concat (symbol-name mode) "-mode-hook")))
-             (_ (and (symbolp ts-hook) (symbolp hook))))
+             ((and (symbolp ts-hook) (symbolp hook))))
     (add-hook ts-hook
-                 #'(lambda ()
-                     (run-hooks hook)))))
+              #'(lambda ()
+                  (run-hooks hook)))))
 
 (when exordium-treesit-modes-enable
   (unless (getenv "ci_tests")
@@ -17,7 +17,6 @@
           (message "Enabling treesit-auto and builtin treesit")
           (use-package treesit-auto
             :requires treesit
-            :after lsp-mode
             :config
             (setq treesit-auto-install 'prompt)
             (global-treesit-auto-mode))
@@ -25,7 +24,6 @@
           (use-package treesit
             :requires treesit
             :ensure nil
-            :after lsp-mode
             :config
             (mapc #'exordium--add-forward-ts-hook
                   '(


### PR DESCRIPTION
I think requiring `treesit` and `treesit-auto` configuration to be evaluated  after `lsp-mode` is excessive. I'm not using the latter (`eglot` fan here), and because of neither of these configurations loads for me.

I also updated a `SPEC` form in `when-let` - i.e., only the `(VALUEFORM)` can be used without creating a binding.