### PR TITLE
Workaround issues with seq-2.24 installation

### DIFF
--- a/init.el
+++ b/init.el
@@ -177,7 +177,17 @@ Each element of the list is in the same form as in `package-pinned-packages'."
 
   (dolist (pkg exordium-extra-packages)
     (update-package pkg has-refreshed)))
-
+
+;; - Some packages (i.e., magit, forge) require seq-2.24.
+;; - Emacs-29 is delivered with seq-2.23.
+;; - Other packages (i.e., compat) require seq-2.23.
+;; - When only magit is installed it requires compat which requires seq-2.23 -> seq is not upgraded
+;; - When only forge is installed is requires magit and compat which requires seq-2.23 -> seq is not upgraded
+;; - When magit is installed followed by installation of forge seq is upgraded to seq-2.24 -> this fails
+;; Force installing the freshest version of seq with errors suppressed:
+(let (debug-on-error)
+  ;; this assumes `package-refresh-contents has been called'
+  (package-install (car (alist-get 'seq package-archive-contents))))
 
 ;;; Path for "require"
 


### PR DESCRIPTION
Had some issues with CI and forge when developing my own tap. So far debugged it to:
- Some packages (i.e., `magit`, `forge`) require `seq-2.24`.
- Emacs-29 is delivered with `seq-2.23`.
- Other packages (i.e., `compat`) require `seq-2.23`.
- When only `magit` is installed it requires `compat` which requires `seq-2.23` -> `seq` is not upgraded
- When only `forge` is installed is requires `magit` and `compat`; the latter requires `seq-2.23` -> `seq` is not upgraded
- When `magit` is installed followed by installation of forge `seq` is upgraded to `seq-2.24` -> this fails

I think there are at least 2 issues here:
- just `(package-install 'forge)` will not install required `seq-2.24` - if I got it right, this is issue with dependency resolution in `package`
- installation of `seq-2.24` fails when `debug-on-error` is t.

This W/A forces installing the freshest version of seq with errors suppressed.