### PR TITLE
Add the taps directories to load path

### DIFF
--- a/init.el
+++ b/init.el
@@ -210,6 +210,12 @@ Each element of the list is in the same form as in `package-pinned-packages'."
 (setq use-package-always-ensure t)
 (setq use-package-compute-statistics t)
 
+;;; remove a package from the builtin list so it can be upgraded
+(defun exordium-ignore-builtin (pkg)
+  (assq-delete-all pkg package--builtins)
+  (assq-delete-all pkg package--builtin-versions))
+
+
 ;;; Load Modules
 (use-package bytecomp :ensure nil)
 (defun recompile-modules ()

--- a/init.el
+++ b/init.el
@@ -196,6 +196,8 @@ Each element of the list is in the same form as in `package-pinned-packages'."
 (add-directory-tree-to-load-path exordium-themes-dir)
 (add-directory-tree-to-load-path exordium-local-dir t)
 
+(add-directory-tree-to-load-path exordium-taps-root)
+
 (setq custom-theme-directory exordium-themes-dir)
 
 

--- a/modules/init-cpp.el
+++ b/modules/init-cpp.el
@@ -49,7 +49,8 @@
 
 ;;; Highlight dead code between "#if 0" and "#endif"
 (add-hook 'c-mode-common-hook 'cpp-highlight-dead-code-hook)
-
+(when exordium-treesit-modes-enable
+  (add-hook 'c-ts--mode-common-hook 'cpp-highlight-dead-code-hook))
 
 ;;; Switch between .h <--> .cpp <--> t.cpp
 

--- a/modules/init-org.el
+++ b/modules/init-org.el
@@ -12,6 +12,7 @@
   "Face for STOP keywords."
   :group 'exordium)
 
+(exordium-ignore-builtin 'org)
 
 (use-package org
   :commands (org-mode)

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -581,7 +581,7 @@ serialize as a JSON array of strings."
   :type '(restricted-sexp
           :match-alternatives (exordium--string-vector-p)))
 
-(defcustom exordium-lsp-clangd-executable ["clangd-15" "clangd-14" "clangd-13" "clangd-12" "clangd-11" "clangd-10" "clangd-9" "clangd"]
+(defcustom exordium-lsp-clangd-executable ["clangd-18" "clangd-17" "clangd-16" "clangd-15" "clangd-14" "clangd-13" "clangd"]
   "List of executable names to search for to run clangd.
 Default is to choose the first that is found via `executable-find'."
   :group 'exordium


### PR DESCRIPTION
Discovered while factoring out some code from a taps' after-init.el that I couldn't (require 'org2blog-init) because it couldn't be found. So this adds taps to load the load path. 