### PR TITLE
Switch to symbol-overlay from highlight-symbol and highlight combo

### DIFF
--- a/.ci/unit-tests.sh
+++ b/.ci/unit-tests.sh
@@ -18,6 +18,7 @@ ${EMACS} -Q --batch \
   (load-file "'"${EMACS_DIR}"'/modules/init-util.t.el")
   (load-file "'"${EMACS_DIR}"'/modules/init-lib.t.el")
   (load-file "'"${EMACS_DIR}"'/modules/init-require.t.el")
+  (load-file "'"${EMACS_DIR}"'/modules/init-highlight.t.el")
   (let ((print-level 50)
         (eval-expression-print-level 50)
         (eval-expression-print-length 1000)

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Keybinding           | Description
 <kbd>C-+</kbd>       | Increase font size (`text-scale-increase`).
 <kbd>C--</kbd>       | Decrease font size (`text-scale-decrease`).
 <kbd>M-C-l</kbd>     | Switch back and forth between the 2 top buffers (from XEmacs).
-<kbd>C-c C-SPC</kbd> | Toggle highlight of the symbol under the cursor (up to 4 different symbols using different colors).
+<kbd>C-c C-SPC</kbd> | Toggle highlight of the symbol under the cursor (by default, up to 8 different symbols using different colors).
 
 Editing:
 
@@ -187,6 +187,23 @@ Tip: if you are looking for a particular key and you know it starts with a
 given prefix, type the prefix followed by <kbd>C-h</kbd>: Emacs will display
 the list of keys starting with that prefix. For example <kbd>C-c C-h</kbd> lists
 all the keys starting with <kbd>C-c</kbd>.
+
+Highlighted symbols:
+
+When a symbol has been highlighted using <kbd>C-C C-SPC</kbd>
+(`symbol-overlay-put`) and a point is placed on the highlighted symbol extra
+keymap is active that allows for example to navigate and edit withing context
+of the symbol.
+
+A few example bindings:
+
+Keybinding     | Description
+-------------- |----------------------------------------------------------
+<kbd>M-n</kbd> | Jump to next location of highlighted symbol at point.
+<kbd>M-p</kbd> | Jump to previous location of highlighted symbol at point.
+<kbd>M-h</kbd> | Display bindings for highlighted symbol at point.
+
+You can change the modifier key (default: <kbd>M</kbd>) by customizing `exordium-highlight-symbol-map-modifier`.
 
 ## Projectile
 

--- a/modules/init-help.el
+++ b/modules/init-help.el
@@ -21,7 +21,6 @@
     (load (file-name-concat (locate-user-emacs-file "modules") "init-require"))))
 (exordium-require 'init-lib)
 (exordium-require 'init-helm)
-(exordium-require 'init-highlight)
 
 ;;; Which Key - display available keybindings in popup.
 (when exordium-enable-which-key
@@ -49,15 +48,6 @@
     :custom
     (helm-describe-variable-function #'helpful-variable)
     (helm-describe-function-function #'helpful-function))
-
-  ;; TODO: seems like `font-lock-add-keywords' destroys all formating in
-  ;; `helpful-mode'.  The former is used by `highlight-symbol' so will
-  ;; not enable it now.
-  ;; (when exordium-highlight-symbol
-  ;;   (use-package highlight-symbol
-  ;;     :defer t
-  ;;     :hook ((helpful-mode . highlight-symbol-mode)
-  ;;            (helpful-mode . highlight-symbol-nav-mode))))
 
   (use-package paren
     :ensure nil

--- a/modules/init-highlight.t.el
+++ b/modules/init-highlight.t.el
@@ -1,0 +1,31 @@
+;;; init-highlight.t.el --- Unit tests for init-highlight.el -*- lexical-binding: t -*-
+
+;;; Commentary:
+;;
+;; To run all tests:
+;;     M-x eval-buffer
+;;     M-x ert
+
+;;; Code:
+
+(eval-when-compile
+  (unless (featurep 'init-require)
+    (load (file-name-concat (locate-user-emacs-file "modules") "init-require"))))
+(exordium-require 'init-highlight)
+
+(require 'ert)
+
+(ert-deftest test-exordium--extract-font-lock-keywords ()
+  (let ((pattern (exordium--extract-font-lock-keywords lisp-el-font-lock-keywords-1)))
+    (should (string-match-p pattern "defun"))
+    (should-not (string-match-p pattern "xdefun"))
+    (should-not (string-match-p pattern "defunx"))
+    (should (string-match-p pattern "cl-defun"))
+    (should-not (string-match-p pattern "xcl-defun"))
+    (should-not (string-match-p pattern "cl-defunx"))))
+
+
+
+(provide 'init-highlight.t)
+
+;;; init-highlight.t.el ends here

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -223,6 +223,29 @@ displayed by the current font default will be used."
   :group 'exordium
   :type  'boolean)
 
+(defcustom exordium-highlight-symbol-map-modifier 'meta
+  "Modifier key for key bindings when point is in a highlighted symbol.
+By default `symbol-overlay-map' (which see) defines single letter
+bindings.  This conflicts with self-insert commands and
+historically it was not Exordium's default.  That is a
+highlighted symbol used to be editable by pressing any letter.
+Setting this variable to a value of KEY will rebind single
+LETTER binding in `symbol-overlay-key' to \"<KEY>-<LETTER>\"
+form.  Possible KEY values are:
+
+  * \\='original - use original \"<LETTER>\" bindings, as defined
+    in `overlay-symbol-map', which see.
+
+  * \\='meta, \\='control, \\='super, or \\='hyper - use
+    \"M-<LETTER>\", \"C-<LETTER>\", \"s-<LETTER>\", or
+    \"H-<LETTER>\" respectively."
+  :type '(radio (const :tag "Original (see `overlay-symbol-map')" original)
+                (const :tag "Meta (`M')" meta)
+                (const :tag "Control (`C')" control)
+                (const :tag "Super (`s')" super)
+                (const :tag "Hyper (`H')" hyper))
+  :group 'exordium)
+
 (defcustom exordium-skip-taps-update nil
   "Whether to skip taps update when updating configuration.
 If set to nil, each tap need to be updated manually,


### PR DESCRIPTION
I have struggled to tune `hightlight-symbol` for the last few weeks. I've
encountered numerous issues, like automatically highlighted symbol not being
visible in current line (with `font-lock`'s background) due to conflict with
`hl-line` mode's overlay, `jit-lock` mode not flushing (required an advice
workaround), automatic highlighting clobbering `helpful-mode`
fontification (haven't got to the bottom of it), conflict in `highlihgt-symbol`
defun (both `highlight` and `highlight-symbol` defined it). It also seem to be
unmaintained - last version on MELPA is from 2016.

I've chosen to switch to `symbol-overlay`. Amongst others it defines its own
symbol highlighting. So I decided to use that instead of Exordium's custom one
that required `highlight`.

The last but not least `symbol-overlay` seems to be maintained and
`modus-themes` - that I use and intent to port to Exordium - has built in
support for it.