### PR TITLE
feat(diff): Add difftastic - a front end to structural diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ might want to check these links:
   management tool).
 * Git: [Magit](http://magit.vc) (git UI);
   [Forge](https://magit.vc/manual/forge/) (work with Git forges);
-  [Git Gutter](https://github.com/syohex/emacs-git-gutter) (diffs in buffer).
+  [Git Gutter](https://github.com/syohex/emacs-git-gutter) (diffs in buffer);
+  [difftastic](https://github.com/pkryger/difftastic.el) (structural diffs).
 * C++:
   * Formatting keys and snippets for the
     [BDE](https://github.com/bloomberg/bde) code style.
@@ -403,6 +404,17 @@ Keybinding            | Description
 <kbd>C-c g b</kbd>    | Toggles git blame mode on and off (`magit-blame-mode`).
 <kbd>C-c g c</kbd>    | Clone a repository (`magit-clone`).
 <kbd>C-c g g</kbd>    | Git grep (`vc-git-grep`) or (`helm-grep-do-git-grep`).
+
+To perform structural diffs you need to install an external tool
+[`difftastic`](https://difftastic.wilfred.me.uk) (see the web page for
+details).  Once `difftastic` has been installed, and you are in either
+`magit-diff` transient, or `magit-blame` transient, or in
+`magit-blame-read-only-mode`:
+
+Keybinding            | Description
+----------------------|-----------------------------------------------------------
+<kbd>D</kbd>          | Run Difftastic diff (guessing what to diff from context) (`difftastic-magit-diff`).
+<kbd>S</kbd>          | Run Difftastic show (`difftastic-magit-show`).
 
 Forge keys:
 

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -21,6 +21,11 @@
 ;; C-c g r           Revert current hunk (asks for confirmation)
 ;;
 ;; C-c ^ d           Show SMerge Dispatch
+;;
+;; When in `magit-diff' or `magit-blame' transient,
+;; or in `magit-blame-read-only-mode':
+;; D                 Run Difftastic diff (guessing what to diff from context)
+;; S                 Run Difftastic show
 
 ;;; Code:
 (eval-when-compile
@@ -221,6 +226,12 @@ with `exordium-magit-quit-session'."
 (use-package magit
   :hook
   (magit-diff-visit-file . exordium-smerge-dispatch-maybe))
+
+;;; Difftastic - a structural diff tool that understands syntax!
+(use-package difftastic-bindings
+  :ensure difftastic
+  :config
+  (difftastic-bindings-mode))
 
 
 ;;; Git gutter fringe: display added/removed/changed lines in the left fringe.


### PR DESCRIPTION
A little bit of shameless plug (my first package on MELPA 😎), but I think it's
really usefull. If you haven't tired `difftastic` yet, I strongly
recommend. Even if as a standalone tool on a terminal.

I have been waiting for the `vc-checkout` (#235) to allow me to seamlessly use
my checked out development version while in Exordium.

Just to give a taste what's the difference is, please check out the screenshot below with exactly the same change being viewed with `difftastic` in top and regular diff (ignoring whitespace changes) in bottom.
<img width="1263" alt="Screenshot 2025-01-09 at 09 06 02" src="https://github.com/user-attachments/assets/ca5dd9f7-990d-46d6-babd-bce0c6e55bb5" />
