### PR TITLE
Assorted improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ request/
 /.cask/
 /forge-database-*.sqlite
 /projects
+/multisession/

--- a/modules/init-elisp.el
+++ b/modules/init-elisp.el
@@ -73,7 +73,7 @@
 (use-package page-break-lines
   :diminish
   :init
-  (defun exordium-page-break-lines-hook ()
+  (defun exordium-page-break-lines ()
     "Enable `page-break-lines' mode.
 When in TUI enable line truncation as well to prevent a rendering
 bug (page break lines wrap around)."
@@ -81,8 +81,8 @@ bug (page break lines wrap around)."
       (set (make-local-variable 'truncate-lines) t))
     (page-break-lines-mode))
   :hook
-  ((emacs-lisp-mode . exordium-page-break-lines-hook)
-   ((compilation-mode help-mode) . page-break-lines-mode)))
+  ((emacs-lisp-mode compilation-mode help-mode emacs-news-mode)
+   . exordium-page-break-lines))
 
 ;;; Animation when evaluating a defun or a region:
 ;; The `eval-sexp-fu-mode' is global so it makes no sense to add it to relevant hooks.

--- a/modules/init-iwyu.el
+++ b/modules/init-iwyu.el
@@ -16,6 +16,7 @@
   (unless (featurep 'init-require)
     (load (file-name-concat (locate-user-emacs-file "modules") "init-require"))))
 (exordium-require 'init-prefs)
+(exordium-require 'init-lib)
 (exordium-require 'init-projectile)
 
 (require 'cl-lib)
@@ -116,12 +117,13 @@ Such constructed list then is appended to arguments in
                (format "include-what-you-use results for file %s:\n" file))
               (read-only-mode)
               (iwyu-mode)
-              (substitute-key-definition
+              (compat-call keymap-substitute ; Since Emacs-29
+               iwyu-mode-map
                'recompile
                (lambda ()
                  (interactive)
                  (iwyu-start-process-for compile-commands-db file))
-                (current-local-map)))
+               compilation-mode-map))
             (apply
              'start-process
              "iwyu-process"

--- a/modules/init-lib.el
+++ b/modules/init-lib.el
@@ -12,6 +12,8 @@
 (exordium-require 'init-prefs)
 
 (require 'cl-lib)
+
+(use-package compat)
 
 ;;; Files
 

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -390,6 +390,7 @@ buffer."
       (not (cl-member (buffer-name) '("scratch-" "*scratch")
                       :test (lambda (buffer-name prefix)
                               (string-prefix-p prefix buffer-name))))
+      (equal (point-min) (point-max))
       (yes-or-no-p
 	   (format "Buffer %S has not been written to a file; kill it? "
 		       (buffer-name (current-buffer))))))

--- a/modules/init-util.el
+++ b/modules/init-util.el
@@ -174,41 +174,44 @@ Uses `current-date-time-format' for the formatting the date/time."
 
 ;;; Duplicate lines
 
-(defun duplicate-line-or-region (arg)
-  "Duplicate current line or region, leaving point in lower line.
-When called with ARG, do this that many times."
-  (interactive "*p")
-  ;; Save the point for undo
-  (setq buffer-undo-list (cons (point) buffer-undo-list))
-  (let ((bol (if mark-active (region-beginning)
-               (save-excursion (beginning-of-line) (point))))
-        eol
-        (num-lines (if mark-active
-                       (count-lines (region-beginning) (region-end))
-                     1))
-        (col (current-column)))
-    (save-excursion
-      (if mark-active
-          (setq eol (region-end))
-        (end-of-line)
-        (setq eol (point)))
-      ;; Disable the recording of undo information
-      (let ((line (buffer-substring bol eol))
-            (buffer-undo-list t))
-        ;; Insert the line arg times
-        (dotimes (_i (if (> arg 0) arg 1))
-          (unless (string-suffix-p "\n" line)
-            (newline))
-          (insert line)))
-      ;; Create the undo information
-      (setq buffer-undo-list (cons (cons eol (point)) buffer-undo-list)))
-    ;; Move the point to the lowest line
-    (forward-line (* arg num-lines))
-    (when (= num-lines 1)
-      ;; Leave the cursor an the same column if we duplicated 1 line
-      (move-to-column col))))
+(if (fboundp 'duplicate-dwim) ;; Since Emacs-29
+    (bind-key "C-c d" #'duplicate-dwim)
 
-(bind-key "C-c d" #'duplicate-line-or-region)
+  (defun duplicate-line-or-region (arg)
+    "Duplicate current line or region, leaving point in lower line.
+When called with ARG, do this that many times."
+    (interactive "*p")
+    ;; Save the point for undo
+    (setq buffer-undo-list (cons (point) buffer-undo-list))
+    (let ((bol (if mark-active (region-beginning)
+                 (save-excursion (beginning-of-line) (point))))
+          eol
+          (num-lines (if mark-active
+                         (count-lines (region-beginning) (region-end))
+                       1))
+          (col (current-column)))
+      (save-excursion
+        (if mark-active
+            (setq eol (region-end))
+          (end-of-line)
+          (setq eol (point)))
+        ;; Disable the recording of undo information
+        (let ((line (buffer-substring bol eol))
+              (buffer-undo-list t))
+          ;; Insert the line arg times
+          (dotimes (_i (if (> arg 0) arg 1))
+            (unless (string-suffix-p "\n" line)
+              (newline))
+            (insert line)))
+        ;; Create the undo information
+        (setq buffer-undo-list (cons (cons eol (point)) buffer-undo-list)))
+      ;; Move the point to the lowest line
+      (forward-line (* arg num-lines))
+      (when (= num-lines 1)
+        ;; Leave the cursor an the same column if we duplicated 1 line
+        (move-to-column col))))
+  (declare-function duplicate-line-or-region nil) ;; to silence compiler
+  (bind-key "C-c d" #'duplicate-line-or-region))
 
 
 ;;; Deleting Spaces

--- a/modules/init-util.t.el
+++ b/modules/init-util.t.el
@@ -241,6 +241,7 @@ Return the BODY return value"
         (progn
           (should buffer)
           (with-current-buffer buffer
+            (insert "test")
             (mocklet ((yes-or-no-p => t :times 1))
               (should (exordium--scratch-kill-buffer-query-function))))
           (with-current-buffer buffer
@@ -261,6 +262,7 @@ Return the BODY return value"
         (progn
           (should buffer)
           (with-current-buffer buffer
+            (insert "test")
             (mocklet ((yes-or-no-p => t :times 1))
               (should (exordium--scratch-kill-buffer-query-function))))
           (with-current-buffer buffer
@@ -283,6 +285,18 @@ Return the BODY return value"
       (when (and file (file-exists-p file))
         (delete-file file)))))
 
+(ert-deftest test-exordium--scratch-kill-buffer-query-function-4 ()
+  (let ((buffer (with-current-buffer (scratch)
+                  (current-buffer))))
+    (unwind-protect
+        (progn
+          (should buffer)
+          (with-current-buffer buffer
+            (mocklet ((yes-or-no-p not-called))
+              (should (exordium--scratch-kill-buffer-query-function)))))
+      (when buffer
+        (kill-buffer buffer))
+        (should-not (buffer-live-p buffer)))))
 
 
 (provide 'init-util.t)

--- a/modules/init-window-manager.el
+++ b/modules/init-window-manager.el
@@ -118,6 +118,12 @@
 
 (use-package ace-window
   :diminish
+  :init
+  (use-package diff-mode
+    :ensure nil
+    :bind
+    (:map diff-mode-map
+     ("M-o" . nil)))
   :custom
   (aw-scope 'frame)
   (aw-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l))


### PR DESCRIPTION
A few improvements, that I think are small enough to avoid creating a separate PR for each.

- don't ask whether to kill empty scratch buffers
- use a proper key substitution in IWYU mode
- use exordium-page-break-lines consistently
- add multisession to gitignore
- don't bind M-o in diff-mode to avoid hijacking ace-window
- use built-in function for duplicate line or region

Please see each commit for a separate changeset