### PR TITLE
Add affixations to buffer switching functions when exordium-help-extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Keybinding                             | Description
 See [Projectile](https://github.com/bbatsov/projectile) documentation for other
 keys.
 
-### Helm
+## Helm
 
 Helm can be set up as a primary completion and selection narrowing framework
 for most commonly used functions. You can achieve that by setting
@@ -351,7 +351,7 @@ Keybinding          | Description
 <kbd>C-x C-f</kbd>  | Find file.
 <kbd>C-x c g</kbd>  | Google suggest.
 
-#### Other Helm tools
+### Other Helm tools
 
 Helm is a pretty good when you need quickly scan search results. The commands below
 will start different search modes. By default, they will use symbol under the point.

--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Keybinding          | Description
 <kbd>M-y</kbd>      | Select yank pop.
 <kbd>C-x b</kbd>    | Switch buffer.
 <kbd>C-x C-f</kbd>  | Find file.
+<kbd>C-x c g</kbd>  | Google suggest.
 
 #### Other Helm tools
 

--- a/modules/init-helm-projectile.el
+++ b/modules/init-helm-projectile.el
@@ -90,6 +90,7 @@ project's file using completion and show it in another window."
     (helm-projectile-on)))
 
 (use-package treemacs-projectile
+  :defer t
   :bind
   (("C-c e" . #'treemacs)
    ("C-c E" . #'treemacs-projectile)))

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -95,6 +95,14 @@
 
 (use-package helm-swoop
   :defer t
+  :init
+  (use-package isearch
+    :ensure nil
+    :defer t
+    :bind
+    (:map isearch-mode-map
+     ("C-S-s" . #'helm-swoop-from-isearch)))
+
   :commands (helm-swoop--edit-complete
              helm-swoop--edit-cancel
              helm-swoop--edit-delete-all-lines)

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -120,12 +120,9 @@
    ("C-c C-k" . #'helm-swoop--edit-cancel)
    ("C-c C-q C-k" . #'helm-swoop--edit-delete-all-lines)))
 
-(use-package helm-xref
-  :after helm
-  :if exordium-helm-everywhere
-  :commands helm-xref
-  :config
-  (setq xref-show-xrefs-function 'helm-xref-show-xrefs))
+(when exordium-helm-everywhere
+  (use-package helm-xref
+    :defer t))
 
 
 

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -66,12 +66,12 @@
   (helm-mode))
 
 (use-package helm-descbinds
-  :after (helm)
+  :defer t
   :bind
-  (("C-h b" . #'helm-descbinds)))
+  ("C-h b" . #'helm-descbinds))
 
 (use-package helm-ag
-  :after (helm)
+  :defer t
   :custom
   (helm-ag-insert-at-point 'symbol)
   :bind
@@ -79,23 +79,22 @@
    ("C-S-f" . #'helm-do-ag-this-file)))
 
 (use-package helm-ag
-  :after (helm)
+  :defer t
   :unless exordium-helm-projectile
   :bind
-  (("C-S-a" . #'helm-ag-project-root)))
+  ("C-S-a" . #'helm-ag-project-root))
 
 (use-package helm-rg
-  :after (helm)
   :defer t)
 
 (use-package helm-rg
-  :after (helm)
   :unless exordium-helm-projectile
+  :defer t
   :bind
-  (("C-S-r" . #'helm-rg)))
+  ("C-S-r" . #'helm-rg))
 
 (use-package helm-swoop
-  :after (helm)
+  :defer t
   :commands (helm-swoop--edit-complete
              helm-swoop--edit-cancel
              helm-swoop--edit-delete-all-lines)

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -18,6 +18,7 @@
 ;; C-S-a             Search with Ag: in current project root.
 ;;                   See also`init-helm-porojectile.el'.
 ;; C-S-s             Helm Swoop
+;; C-x c g           Helm Google suggest.
 
 ;;; Code:
 
@@ -28,6 +29,9 @@
 
 (use-package helm
   :diminish
+  :bind
+  (:map helm-command-map
+   ("g" . #'helm-google-suggest))
   :custom
   (helm-split-window-default-side 'other)
   (helm-split-window-other-side-when-one-window 'right)


### PR DESCRIPTION
This ensures consistency when switching to buffers using different methods, for
example `swich-to-buffer`, <kbd>C-x b</kbd>, `swich-to-buffer-other-window`,
<kbd>C-x 4 b</kbd>, or `projectile-switch-to-buffer`, <kbd>C-c p b</kbd>.

Using the opportunity to add a few minor fixes, and a couple of new keybindings.

As usual, please see individual commits for details.