### PR TITLE
Disable org-level-1 overline in Tommorrow theme

### DIFF
--- a/themes/color-theme-tomorrow.el
+++ b/themes/color-theme-tomorrow.el
@@ -324,7 +324,7 @@ names to which it refers are bound."
      ;; Org
      (org-level-1 ((t
                     ,(append `(:foreground ,green
-                               :overline ,green
+                               :overline nil
                                :inherit nil
                                :extend t)
                              (if exordium-theme-use-big-font `(:height ,exordium-height-plus-4) nil)))))


### PR DESCRIPTION
This PR makes a simple change to the look of org-mode level 1 headline, removing the overline. It is visually distracting for long org documents, and it is also different from all the other themes in Exordium.

Off-topic, but I discovered how to create custom startup options for org-mode. One can re-add this overline by adding `#+startup: showline` in an org file, provided that you have the following code in one of your Exordium taps:
```elisp
;;; Custom startup options for org-mode
(defvar my-org-mode-showlines nil)
(add-to-list 'org-startup-options '("showlines" my-org-mode-showlines t))
(add-hook 'org-mode-hook
          (lambda ()
            (when my-org-mode-showlines
              (face-remap-add-relative 'org-level-1
                                       (with-tomorrow-colors 'night `(:overline ,green))))))

```