### PR TITLE
feat: Customiseable window splitting direction

### DIFF
--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -34,8 +34,18 @@
    ("g" . #'helm-google-suggest))
   :custom
   (helm-split-window-default-side 'other)
-  (helm-split-window-other-side-when-one-window 'right)
-  (helm-buffer-details-flag nil)
+
+  (helm-split-window-other-side-when-one-window
+   (if (eq exordium-split-window-preffered-direction 'horizontal)
+       'right
+     'below))
+
+  (helm-split-window-preferred-function
+   (if (eq exordium-split-window-preffered-direction 'longest)
+       #'split-window-sensibly
+     #'helm-split-window-default-fn))
+
+  (helm-buffer-max-length nil)
   (helm-completion-style (cond
                           ((and exordium-helm-fuzzy-match
                                 (eq exordium-helm-completion-style 'helm))
@@ -207,7 +217,10 @@
              helm-swoop--edit-cancel
              helm-swoop--edit-delete-all-lines)
   :custom
-  (helm-swoop-split-direction 'split-window-horizontally)
+  (helm-swoop-split-direction (pcase exordium-split-window-preffered-direction
+                                ('longest #'split-window-sensibly)
+                                ('horizontal #'split-window-horizontally)
+                                (_ #'split-window-vertically)))
   :bind
   (("C-S-s" . #'helm-swoop)
    ;; Use similar bindings to `helm-ag-edit'

--- a/modules/init-helm.el
+++ b/modules/init-helm.el
@@ -36,12 +36,12 @@
   (helm-split-window-default-side 'other)
 
   (helm-split-window-other-side-when-one-window
-   (if (eq exordium-split-window-preffered-direction 'horizontal)
+   (if (eq exordium-split-window-preferred-direction 'horizontal)
        'right
      'below))
 
   (helm-split-window-preferred-function
-   (if (eq exordium-split-window-preffered-direction 'longest)
+   (if (eq exordium-split-window-preferred-direction 'longest)
        #'split-window-sensibly
      #'helm-split-window-default-fn))
 
@@ -217,7 +217,7 @@
              helm-swoop--edit-cancel
              helm-swoop--edit-delete-all-lines)
   :custom
-  (helm-swoop-split-direction (pcase exordium-split-window-preffered-direction
+  (helm-swoop-split-direction (pcase exordium-split-window-preferred-direction
                                 ('longest #'split-window-sensibly)
                                 ('horizontal #'split-window-horizontally)
                                 (_ #'split-window-vertically)))

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -44,7 +44,7 @@ evaluating `font-family-list'."
   :group 'exordium
   :type  'integer)
 
-(defcustom exordium-split-window-preffered-direction 'vertical
+(defcustom exordium-split-window-preferred-direction 'vertical
   "The first direction tried when Emacs needs to split a window.
 This variable controls in which order
 `split-window-sensibly' (which see) will try to split the window.

--- a/modules/init-prefs.el
+++ b/modules/init-prefs.el
@@ -44,6 +44,37 @@ evaluating `font-family-list'."
   :group 'exordium
   :type  'integer)
 
+(defcustom exordium-split-window-preffered-direction 'vertical
+  "The first direction tried when Emacs needs to split a window.
+This variable controls in which order
+`split-window-sensibly' (which see) will try to split the window.
+That order specially matters when both dimensions of the frame
+are long enough to be split according to `split-width-threshold'
+and `split-height-threshold'.  It is recommended to
+experimentally set latter options to values that are compatible
+with specific Emacs configuration (as they may differ depending
+on frame size (or a screen size if Emacs run in full screen) and
+chosen font size.
+
+If the value is `vertical' (the default), `split-window-sensibly'
+tries to split vertically first and then horizontally.  If the
+value is `horizontal' it does the opposite.  If the value
+`longest' the first direction tried depends on the frame shape:
+in landscape orientation it will be like `horizontal', but in
+portrait it will be like `vertical'.  Basically, the longest of
+the two dimension is split first.
+
+If both `split-width-threshold' and `split-height-threshold'
+cannot be satisfied, it will fallback to split vertically."
+  :group 'exordium
+  :type '(radio
+          (const :tag "Try to split vertically first"
+                 vertical)
+          (const :tag "Try to split horizontally first"
+                 horizontal)
+          (const :tag "Try to split along the longest edge"
+                 longest)))
+
 (defcustom exordium-line-mode t
   "Whether the current line is highlighted or not."
   :group 'exordium

--- a/modules/init-window-manager.el
+++ b/modules/init-window-manager.el
@@ -34,7 +34,7 @@
 (use-package window
   :ensure nil
   :custom
-  (split-window-preferred-direction exordium-split-window-preffered-direction)
+  (split-window-preferred-direction exordium-split-window-preferred-direction)
   :functions (exordium--window-try-vertical-split
               exordium--window-try-horizontal-split
               exordium-split-window-sensibly)
@@ -56,8 +56,8 @@
       "Split WINDOW in a way suitable for `display-buffer'."
       (let ((window (or window (selected-window))))
         (or (if (or
-                 (eq exordium-split-window-preffered-direction 'horizontal)
-                 (and (eq exordium-split-window-preffered-direction 'longest)
+                 (eq exordium-split-window-preferred-direction 'horizontal)
+                 (and (eq exordium-split-window-preferred-direction 'longest)
                       (> (frame-width) (frame-height))))
                 (or (exordium--window-try-horizontal-split window)
                     (exordium--window-try-vertical-split window))

--- a/modules/init-window-manager.el
+++ b/modules/init-window-manager.el
@@ -26,6 +26,66 @@
 
 
 ;;; Code:
+(eval-when-compile
+  (unless (featurep 'init-require)
+    (load (file-name-concat (locate-user-emacs-file "modules") "init-require"))))
+(exordium-require 'init-prefs)
+
+(use-package window
+  :ensure nil
+  :custom
+  (split-window-preferred-direction exordium-split-window-preffered-direction)
+  :functions (exordium--window-try-vertical-split
+              exordium--window-try-horizontal-split
+              exordium-split-window-sensibly)
+  :init
+  (unless (boundp 'split-window-preferred-direction) ;; Until Emacs-29
+    (defun exordium--window-try-vertical-split (window)
+      "Try split WINDOW vertically."
+      (when (window-splittable-p window)
+        (with-selected-window window
+          (split-window-below))))
+
+    (defun exordium--window-try-horizontal-split (window)
+      "Try split WINDOW horizontally."
+      (when (window-splittable-p window t)
+        (with-selected-window window
+          (split-window-right))))
+
+    (defun exordium-split-window-sensibly (&optional window)
+      "Split WINDOW in a way suitable for `display-buffer'."
+      (let ((window (or window (selected-window))))
+        (or (if (or
+                 (eq exordium-split-window-preffered-direction 'horizontal)
+                 (and (eq exordium-split-window-preffered-direction 'longest)
+                      (> (frame-width) (frame-height))))
+                (or (exordium--window-try-horizontal-split window)
+                    (exordium--window-try-vertical-split window))
+              (or (exordium--window-try-vertical-split window)
+                  (exordium--window-try-horizontal-split window)))
+	        (and
+             ;; If WINDOW is the only usable window on its frame (it is
+             ;; the only one or, not being the only one, all the other
+             ;; ones are dedicated) and is not the minibuffer window, try
+             ;; to split it vertically disregarding the value of
+             ;; `split-height-threshold'.
+             (let ((frame (window-frame window)))
+               (or
+                (eq window (frame-root-window frame))
+                (catch 'done
+                  (walk-window-tree (lambda (w)
+                                      (unless (or (eq w window)
+                                                  (window-dedicated-p w))
+                                        (throw 'done nil)))
+                                    frame nil 'nomini)
+                  t)))
+	         (not (window-minibuffer-p window))
+             (let ((split-height-threshold 0))
+               (exordium--window-try-vertical-split window))))))
+
+    ;; Helm directly calls `split-window-sensibly'
+    (advice-add 'split-window-sensibly :override
+                #'exordium-split-window-sensibly)))
 
 (use-package windmove
   :ensure nil


### PR DESCRIPTION
Port functionality of splitting by the longest direction from Emacs 30 and
adjust `helm` to use the same functions to perform splits.

@philippe-grenet I hope this is a reasonable solution to [the issue](https://github.com/emacs-exordium/exordium/pull/227#discussion_r1874938162)  that has been flagged in #227.