### PR TITLE
fix: Update searching for function arguments parenthesis

### DIFF
--- a/modules/init-bde-style.el
+++ b/modules/init-bde-style.el
@@ -527,9 +527,10 @@ parenthesis has been found within the first
   "Return the position of the function argument list closing parenthesis.
 The search starts after the specified FROM position and ends when
 either a semicolon, `inline-open', `defun-open',
-`member-init-intro', or `noexcept' has been encountered.  Return
-nil when no qualifying parenthesis has been found withing the
-first `exordium-bde-search-max-bound' characters."
+`member-init-intro', `brace-entry-open', or `noexcept' has been
+encountered.  Return nil when no qualifying parenthesis has been
+found withing the first `exordium-bde-search-max-bound'
+characters."
   (when from
     (save-excursion
       (goto-char from)
@@ -551,7 +552,10 @@ first `exordium-bde-search-max-bound' characters."
                    ;; breaks more functionality. It would require some support
                    ;; in `bde-align-funcdecl', i.e., to move initializer list
                    ;; after the c-tor arguments, before aligning.
-                   (when (cl-member '(inline-open defun-open member-init-intro)
+                   (when (cl-member '(inline-open
+                                      defun-open
+                                      member-init-intro
+                                      brace-entry-open)
                                     (c-guess-basic-syntax)
                                     :test any-of-is-car-of)
                      (throw 'pos candidate)))
@@ -583,7 +587,8 @@ been found."
                  (exordium-bde-arglist-at-point--open-paren-position
                   (nth 1
                        (car (cl-member '(topmost-intro
-                                         topmost-intro-cont)
+                                         topmost-intro-cont
+                                         brace-list-intro)
                                        basic-syntax
                                        :test any-of-is-car-of)))
                   t)


### PR DESCRIPTION
In Emacs 30.2 the syntax entries has changed:

- for the opening brace after function argument list to
  `brace-entry-open` (form `inline-open` in Emacs 29.4 and Emacs 30.1).

- for the opening parenthesis for argument list to `brace-list-intro` (from
  `topmost-intro` in Emacs 29.4 and Emacs 30.1).

This fixes the following failure (as observed in
https://github.com/emacs-exordium/exordium/actions/runs/14177899574/job/39717058426):

```
4 unexpected results:
   FAILED  test-exordium-bde-bounds-of-arglist-at-point-commas-in-assign-1  ((should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point)) (cons 24 222))) :form (equal nil (24 . 222)) :value nil :explanation (different-types nil (24 . 222)))
   FAILED  test-exordium-bde-bounds-of-arglist-at-point-commas-in-assign-2  ((should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point)) (cons 24 222))) :form (equal nil (24 . 222)) :value nil :explanation (different-types nil (24 . 222)))
   FAILED  test-exordium-bde-bounds-of-arglist-at-point-commas-in-assign-3  ((should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point)) (cons 24 222))) :form (equal nil (24 . 222)) :value nil :explanation (different-types nil (24 . 222)))
   FAILED  test-exordium-bde-bounds-of-arglist-at-point-commas-in-assign-4  ((should (equal (with-test-case-return tst (exordium-bde-bounds-of-arglist-at-point)) (cons 24 222))) :form (equal nil (24 . 222)) :value nil :explanation (different-types nil (24 . 222)))
```