### PR TITLE
feat: Fixes for Emacs 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ General:
 Keybinding           | Description
 ---------------------|---------------------------------------------------------
 <kbd>C-z</kbd>       | Undo! (`undo`).
-<kbd>C-\`</kbd>      | `kill-this-buffer` (faster than <kbd>C-x k</kbd>).
+<kbd>C-\`</kbd>      | `kill-current-buffer` (faster than <kbd>C-x k</kbd>).
 <kbd>C-x C-r</kbd>   | Open recent file (completes open file with <kbd>C-x C-f</kbd>).
 <kbd>M-g</kbd>       | `goto-line` (prompts for a line number).
 <kbd>C-+</kbd>       | Increase font size (`text-scale-increase`).

--- a/modules/init-forge.el
+++ b/modules/init-forge.el
@@ -250,6 +250,9 @@ ask for SOURCE and TARGET."
     :ensure magit
     :defer t
     :autoload (magit-refresh))
+  (use-package closql
+    :defer t
+    :autoload (closql-delete))
 
   (defun exordium-forge-cleanup-known-repositories--question (to-delete &optional number)
     "Return a question about deletion of up to NUMBER of TO-DELETE repositories.

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -245,6 +245,9 @@ with `exordium-magit-quit-session'."
 ;;; Difftastic - a structural diff tool that understands syntax!
 (use-package difftastic-bindings
   :ensure difftastic
+  :demand t
+  :hook
+  (difftastic-diff-visit-file . exordium-smerge-dispatch-maybe)
   :config
   (difftastic-bindings-mode))
 

--- a/modules/init-git.el
+++ b/modules/init-git.el
@@ -167,7 +167,8 @@ with `exordium-magit-quit-session'."
 
 (use-package transient
   :functions exordium-smerge-dispatch
-  :autoload (transient-prefix
+  :autoload (transient--set-layout
+             transient-prefix
              transient-setup
              transient-suffix)
   :config

--- a/modules/init-lib.el
+++ b/modules/init-lib.el
@@ -12,6 +12,7 @@
 (exordium-require 'init-prefs)
 
 (require 'cl-lib)
+(require 'elec-pair)
 
 (use-package compat)
 

--- a/modules/init-look-and-feel.el
+++ b/modules/init-look-and-feel.el
@@ -281,7 +281,7 @@ Set FONT and SIZE if they are passed as arguments."
 (bind-key "M-g" #'goto-line)
 (when exordium-keyboard-ctrl-z-undo
   (bind-key "C-z" #'undo))
-(bind-key "C-`" #'kill-this-buffer)
+(bind-key "C-`" #'kill-current-buffer)
 
 ;;; Meta-Control-L = switch to last buffer
 (defun switch-to-other-buffer ()

--- a/modules/init-osx.el
+++ b/modules/init-osx.el
@@ -37,6 +37,17 @@
      '("-l" "-i")))
   :hook (after-init . exec-path-from-shell-initialize))
 
+;; Workaround for https://debbugs.gnu.org/cgi/bugreport.cgi?bug=77944
+(use-package man ;; Until Emacs-31 (perhaps fix in Emacs-30.2)
+  :ensure nil
+  :defer t
+  :autoload (Man-init-defvars)
+  :custom
+  (Man-sed-command (or (executable-find "gsed") "sed"))
+  (Man-awk-command (or (executable-find "gawk") "awk"))
+  :config
+  (Man-init-defvars))
+
 (provide 'init-osx)
 
 ;;; init-osx.el ends here

--- a/modules/init-window-manager.el
+++ b/modules/init-window-manager.el
@@ -39,7 +39,7 @@
               exordium--window-try-horizontal-split
               exordium-split-window-sensibly)
   :init
-  (unless (boundp 'split-window-preferred-direction) ;; Until Emacs-29
+  (unless (boundp 'split-window-preferred-direction) ;; Until Emacs-31
     (defun exordium--window-try-vertical-split (window)
       "Try split WINDOW vertically."
       (when (window-splittable-p window)


### PR DESCRIPTION
Below are a few small fixes I discovered while using Emacs from master branch
(30.1.50), if you're on macOS and fan of Mitsuharu's Emacs-mac you can check
out https://github.com/pkryger/homebrew-emacsmacport-exp `</shameless-plug>`).

## fix(git): Add autoload for transient--set-layout

Emacs-snapshot has started to complain about that with:

```
init-git.el: Warning: the function ‘transient--set-layout’ might not be defined at runtime.
```

## fix(osx): Workaround for broken man in Emacs-30.1 on macOS

Recent change has introduced a bug where a man page cannot be displayed. This
is annoying in places like transient prefixes, where one can invoke a manual
with just `C-h C-h`.

## feat(git): Show smerge-dispatch after visiting file from difftastic

Show `exordium-smerge-dispatch` if necessary after visiting a file with one of
the `difftastic-diff-visit-file` or `difftastic-diff-visit-worktree-file`
(bound respectively to `RET` and `C-RET` in `difftastic-mode`).

This is similar to what happens today after visiting a file with
`magit-diff-visit-file` and `magit-diff-visit-worktree-file` from
`magit-diff-mode` buffers.

## fix(lib): Add missing require for elec-pair

To silence the following compiler warnings:
```
init-lib.el:73:25: Warning: reference to free variable ‘electric-pair-pairs’
init-lib.el:75:25: Warning: reference to free variable ‘electric-pair-text-pairs’
```

## fix(forge): Add missing autoload for closeql-delete

To silence the following compiler warning:
```
init-forge.el:323:23: Warning: the function ‘closql-delete’ might not be defined at runtime.
```

## doc(window-manager): Update Emacs version for smarter window split

Ultimately, the new implementation of `split-window-sensibly` supporting
`longest` direction didn't make it to Emacs-30.1 and it's has not been yet
merged into emacs-30 branch. Seems that we need to wait for Emacs-31 for that.

## fix(look-and-feel): Use kill-current-buffer as a command for C-`

When using command `kill-this-buffer` Emacs 30.1 complains with
`kill-this-buffer must be bound to an event with parameters`.

This seems to has been changed sometime in Emacs 27 timeframe, see
https://github.com/emacs-mirror/emacs/commit/2e4f4c9.